### PR TITLE
FXSD-900 Google Analytics Implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Version 0.2.3 (14 May, 2025)
+* [New] SDK now persists `session_id` across launches and renews it automatically after `sessionTimeout` (default 30 min, configurable).
+
 Version 0.2.2 (13 January, 2022)
 * [Fix](https://github.com/freshpaint-io/freshpaint-ios/pull/3) Fixed issue where integration settings were not initialized properly.
 

--- a/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
+++ b/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
@@ -27,6 +27,7 @@ NSString *const FPMENT_WRITE_KEY = @"5bd86532-4cc1-4b18-8392-880be8eb0e3d";
     FPAnalyticsConfiguration *configuration = [FPAnalyticsConfiguration configurationWithWriteKey:FPMENT_WRITE_KEY];
     configuration.trackApplicationLifecycleEvents = YES;
     configuration.flushAt = 1;
+    configuration.sessionTimeout = 120; 
     [FPAnalytics setupWithConfiguration:configuration];
     [[FPAnalytics sharedAnalytics] identify:@"Prateek" traits:nil options: @{
                                                                               @"anonymousId":@"test_anonymousId"

--- a/Examples/CocoapodsExample/Podfile.lock
+++ b/Examples/CocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Freshpaint (0.2.1)
+  - Freshpaint (0.2.3)
 
 DEPENDENCIES:
   - Freshpaint (from `../../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Freshpaint: 97a8a42cca7d9c10922c55a4483679640414b9a8
+  Freshpaint: e8ff9731b16c054f4f7d80b0fe9f0b92fe6b15e1
 
 PODFILE CHECKSUM: ae9f8432a20c5956836d66d7633ac1826053538e
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.16.2

--- a/Freshpaint.podspec
+++ b/Freshpaint.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Freshpaint"
   s.module_name      = "FreshpaintSDK"
-  s.version          = "0.2.2"
+  s.version          = "0.2.3"
   s.summary          = "Integrate Freshpaint with your iOS App."
 
   s.description      = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://freshpaint.io/"
   s.author           = { "Freshpaint" => "michael@freshpaint.io" }
   s.license          = "MIT"
-  s.source           = { "git" => "https://github.com/freshpaint-io/freshpaint-ios.git", "tag" => "0.2.2" }
+  s.source           = { "git" => "https://github.com/freshpaint-io/freshpaint-ios.git", "tag" => "0.2.3" }
 
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '9.0'

--- a/Freshpaint/Classes/FPAnalytics.h
+++ b/Freshpaint/Classes/FPAnalytics.h
@@ -218,6 +218,8 @@ NS_SWIFT_NAME(Freshpaint)
 /** Returns the registered device token of this device */
 - (NSString *)getDeviceToken;
 
+- (NSString *)validatedSessionId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -27,6 +27,7 @@ static FPAnalytics *__sharedInstance = nil;
 @property (nonatomic, strong) FPStoreKitTracker *storeKitTracker;
 @property (nonatomic, strong) FPIntegrationsManager *integrationsManager;
 @property (nonatomic, strong) FPMiddlewareRunner *runner;
+@property (nonatomic, strong) FPState *state;
 @end
 
 
@@ -45,6 +46,8 @@ static FPAnalytics *__sharedInstance = nil;
     NSCParameterAssert(configuration != nil);
 
     if (self = [self init]) {
+        self.state = [FPState sharedInstance];
+
         self.oneTimeConfiguration = configuration;
         self.enabled = YES;
 
@@ -534,7 +537,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 {
     // this has to match the actual version, NOT what's in info.plist
     // because Apple only accepts X.X.X as versions in the review process.
-    return @"0.2.2";
+    return @"0.2.3";
 }
 
 #pragma mark - Helpers
@@ -566,5 +569,14 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     // Could probably do more things with callback later, but we don't use it yet.
     [self.runner run:context callback:nil];
 }
+
+- (NSString *)validatedSessionId
+{
+    NSTimeInterval timeout = self.state.configuration.sessionTimeout ?: 1800;
+    [self.state validateOrRenewSessionWithTimeout:timeout];
+    
+    return self.state.userInfo.sessionId;
+}
+
 
 @end

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -255,6 +255,4 @@ NS_SWIFT_NAME(FreshpaintExperimental)
  */
 @property (nonatomic, strong, nullable) FPRawModificationBlock rawFreshpaintModificationBlock;
 
-@property (nonatomic, assign) NSTimeInterval sessionTimeout; // Default: 30 min (1800 segundos)
-
 @end

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -229,6 +229,12 @@ NS_SWIFT_NAME(FreshpaintConfiguration)
  */
 @property (nonatomic, readonly, nonnull) FPAnalyticsExperimental *experimental;
 
+/**
+ * The maximum duration of a user session before it expires and is renewed.
+ * Measured in seconds. Default value is 30 minutes (1800 seconds).
+ * Session timeout interval, expressed in seconds.
+ * For example, a value of 1800 represents 30 minutes.
+ */
 @property (nonatomic, assign) NSTimeInterval sessionTimeout;
 
 @end

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -255,6 +255,4 @@ NS_SWIFT_NAME(FreshpaintExperimental)
  */
 @property (nonatomic, strong, nullable) FPRawModificationBlock rawFreshpaintModificationBlock;
 
-@property (nonatomic, assign) NSTimeInterval sessionTimeout; // Default: 30 min (1800 seconds)
-
 @end

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -255,4 +255,6 @@ NS_SWIFT_NAME(FreshpaintExperimental)
  */
 @property (nonatomic, strong, nullable) FPRawModificationBlock rawFreshpaintModificationBlock;
 
+@property (nonatomic, assign) NSTimeInterval sessionTimeout; // Default: 30 min (1800 seconds)
+
 @end

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -229,6 +229,8 @@ NS_SWIFT_NAME(FreshpaintConfiguration)
  */
 @property (nonatomic, readonly, nonnull) FPAnalyticsExperimental *experimental;
 
+@property (nonatomic, assign) NSTimeInterval sessionTimeout;
+
 @end
 
 #pragma mark - Experimental

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -255,4 +255,6 @@ NS_SWIFT_NAME(FreshpaintExperimental)
  */
 @property (nonatomic, strong, nullable) FPRawModificationBlock rawFreshpaintModificationBlock;
 
+@property (nonatomic, assign) NSTimeInterval sessionTimeout; // Default: 30 min (1800 segundos)
+
 @end

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.m
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.m
@@ -71,6 +71,7 @@
         self.payloadFilters = @{
             @"(fb\\d+://authorize#access_token=)([^ ]+)": @"$1((redacted/fb-auth-token))"
         };
+        self.sessionTimeout = 1800;
         _factories = [NSMutableArray array];
 #if TARGET_OS_IPHONE
         if ([UIApplication respondsToSelector:@selector(sharedApplication)]) {

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.m
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.m
@@ -71,7 +71,6 @@
         self.payloadFilters = @{
             @"(fb\\d+://authorize#access_token=)([^ ]+)": @"$1((redacted/fb-auth-token))"
         };
-        _sessionTimeout = 1800;
         _factories = [NSMutableArray array];
 #if TARGET_OS_IPHONE
         if ([UIApplication respondsToSelector:@selector(sharedApplication)]) {

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.m
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.m
@@ -71,6 +71,7 @@
         self.payloadFilters = @{
             @"(fb\\d+://authorize#access_token=)([^ ]+)": @"$1((redacted/fb-auth-token))"
         };
+        _sessionTimeout = 1800;
         _factories = [NSMutableArray array];
 #if TARGET_OS_IPHONE
         if ([UIApplication respondsToSelector:@selector(sharedApplication)]) {

--- a/Freshpaint/Classes/FPFreshpaintIntegration.m
+++ b/Freshpaint/Classes/FPFreshpaintIntegration.m
@@ -395,6 +395,11 @@ NSUInteger const kFPBackgroundTaskInvalid = 0;
     [payload setObject:iso8601FormattedString([NSDate date]) forKey:@"sentAt"];
     [payload setObject:batch forKey:@"batch"];
 
+    [self.state validateOrRenewSessionWithTimeout:self.configuration.sessionTimeout ?: 1800];
+    NSString *sessionParameter = [NSString stringWithFormat:@"$%@", self.state.userInfo.sessionId];
+
+    [payload setObject:sessionParameter forKey:@"$session_id"];
+
     FPLog(@"%@ Flushing %lu of %lu queued API calls.", self, (unsigned long)batch.count, (unsigned long)self.queue.count);
     FPLog(@"Flushing batch %@.", payload);
 

--- a/Freshpaint/Classes/FPFreshpaintIntegration.m
+++ b/Freshpaint/Classes/FPFreshpaintIntegration.m
@@ -395,11 +395,6 @@ NSUInteger const kFPBackgroundTaskInvalid = 0;
     [payload setObject:iso8601FormattedString([NSDate date]) forKey:@"sentAt"];
     [payload setObject:batch forKey:@"batch"];
 
-    [self.state validateOrRenewSessionWithTimeout:self.configuration.sessionTimeout ?: 1800];
-    NSString *sessionParameter = [NSString stringWithFormat:@"$%@", self.state.userInfo.sessionId];
-
-    [payload setObject:sessionParameter forKey:@"$session_id"];
-
     FPLog(@"%@ Flushing %lu of %lu queued API calls.", self, (unsigned long)batch.count, (unsigned long)self.queue.count);
     FPLog(@"Flushing batch %@.", payload);
 

--- a/Freshpaint/Classes/FPHTTPClient.m
+++ b/Freshpaint/Classes/FPHTTPClient.m
@@ -69,7 +69,15 @@ static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
 - (nullable NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler
 {
-    //    batch = FPCoerceDictionary(batch);
+    [self.state validateOrRenewSessionWithTimeout:self.configuration.sessionTimeout ?: 1800];
+    NSString *sessionParameter = [NSString stringWithFormat:@"$%@", self.state.userInfo.sessionId];
+
+    NSMutableDictionary *updatedBatch = [batch mutableCopy];
+
+    updatedBatch[@"$session_id"] = sessionParameter;
+
+    batch = [updatedBatch copy];
+
     NSURLSession *session = [self sessionForWriteKey:writeKey];
 
     NSURL *url = [FRESHPAINT_API_BASE URLByAppendingPathComponent:@"/"];

--- a/Freshpaint/Classes/FPHTTPClient.m
+++ b/Freshpaint/Classes/FPHTTPClient.m
@@ -69,15 +69,7 @@ static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
 - (nullable NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler
 {
-    [self.state validateOrRenewSessionWithTimeout:self.configuration.sessionTimeout ?: 1800];
-    NSString *sessionParameter = [NSString stringWithFormat:@"$%@", self.state.userInfo.sessionId];
-
-    NSMutableDictionary *updatedBatch = [batch mutableCopy];
-
-    updatedBatch[@"$session_id"] = sessionParameter;
-
-    batch = [updatedBatch copy];
-
+    //    batch = FPCoerceDictionary(batch);
     NSURLSession *session = [self sessionForWriteKey:writeKey];
 
     NSURL *url = [FRESHPAINT_API_BASE URLByAppendingPathComponent:@"/"];

--- a/Freshpaint/Info.plist
+++ b/Freshpaint/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.2</string>
+	<string>0.2.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Freshpaint/Internal/FPState.h
+++ b/Freshpaint/Internal/FPState.h
@@ -16,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *anonymousId;
 @property (nonatomic, strong, nullable) NSString *userId;
 @property (nonatomic, strong, nullable) NSDictionary *traits;
-@property (nonatomic, strong) NSString *sessionId;
-@property (nonatomic, assign) NSTimeInterval lastSessionTimestamp;
 @end
 
 @interface FPPayloadContext: NSObject

--- a/Freshpaint/Internal/FPState.h
+++ b/Freshpaint/Internal/FPState.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *anonymousId;
 @property (nonatomic, strong, nullable) NSString *userId;
 @property (nonatomic, strong, nullable) NSDictionary *traits;
+@property (nonatomic, strong) NSString *sessionId;
+@property (nonatomic, assign) NSTimeInterval lastSessionTimestamp;
 @end
 
 @interface FPPayloadContext: NSObject

--- a/Freshpaint/Internal/FPState.h
+++ b/Freshpaint/Internal/FPState.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *anonymousId;
 @property (nonatomic, strong, nullable) NSString *userId;
 @property (nonatomic, strong, nullable) NSDictionary *traits;
+@property (nonatomic, strong) NSString *sessionId;
+@property (nonatomic, assign) NSTimeInterval lastSessionTimestamp;
 @end
 
 @interface FPPayloadContext: NSObject
@@ -40,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init __unavailable;
 
 - (void)setUserInfo:(FPUserInfo *)userInfo;
+- (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -191,6 +191,8 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         _stateQueue = dispatch_queue_create("com.freshpaint.state.queue", DISPATCH_QUEUE_CONCURRENT);
         self.userInfo = [[FPUserInfo alloc] initWithState:self];
         self.context = [[FPPayloadContext alloc] initWithState:self];
+        self.userInfo.sessionId = GenerateUUIDString();
+        self.userInfo.lastSessionTimestamp = [[NSDate date] timeIntervalSince1970];
     }
     return self;
 }
@@ -207,6 +209,19 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         value = block();
     });
     return value;
+}
+
+- (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout {
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    NSTimeInterval diff = now - self.userInfo.lastSessionTimestamp;
+
+    NSLog(@"[Session] now=%.0f, last=%.0f, diff=%.0f s, timeout=%.0f s",
+          now, self.userInfo.lastSessionTimestamp, diff, timeout);
+
+    if (diff > timeout) {
+        self.userInfo.sessionId = GenerateUUIDString();
+        self.userInfo.lastSessionTimestamp = now;
+    }
 }
 
 @end

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -191,8 +191,6 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         _stateQueue = dispatch_queue_create("com.freshpaint.state.queue", DISPATCH_QUEUE_CONCURRENT);
         self.userInfo = [[FPUserInfo alloc] initWithState:self];
         self.context = [[FPPayloadContext alloc] initWithState:self];
-        self.userInfo.sessionId = GenerateUUIDString();
-        self.userInfo.lastSessionTimestamp = [[NSDate date] timeIntervalSince1970];
     }
     return self;
 }
@@ -209,14 +207,6 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         value = block();
     });
     return value;
-}
-
-- (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout {
-    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
-    if (now - self.userInfo.lastSessionTimestamp > timeout) {
-        self.userInfo.sessionId = GenerateUUIDString();
-    }
-    self.userInfo.lastSessionTimestamp = now;
 }
 
 @end

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -191,6 +191,8 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         _stateQueue = dispatch_queue_create("com.freshpaint.state.queue", DISPATCH_QUEUE_CONCURRENT);
         self.userInfo = [[FPUserInfo alloc] initWithState:self];
         self.context = [[FPPayloadContext alloc] initWithState:self];
+        self.userInfo.sessionId = GenerateUUIDString();
+        self.userInfo.lastSessionTimestamp = [[NSDate date] timeIntervalSince1970];
     }
     return self;
 }
@@ -207,6 +209,14 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         value = block();
     });
     return value;
+}
+
+- (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout {
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    if (now - self.userInfo.lastSessionTimestamp > timeout) {
+        self.userInfo.sessionId = GenerateUUIDString();
+    }
+    self.userInfo.lastSessionTimestamp = now;
 }
 
 @end


### PR DESCRIPTION
**What does this PR do?**

- Adds reliable session handling to the iOS SDK:
- Persists sessionId and its timestamp across launches.
- Automatically renews the UUID after the configurable sessionTimeout (default 30 min).

**Where should the reviewer start?**

- FPState.{h,m} – new properties, persistence + renewal logic.
- FPAnalytics.{h,m} – private state ivar and validatedSessionId.
- FPAnalyticsConfiguration.{h,m} – public sessionTimeout.
- FPFreshpaintIntegration.m – updated sendData: that writes the ID into properties/context.

**How should this be manually tested?**

- Launch the sample app, trigger any event, inspect payload → properties.session_id present.
- Background app < timeout → trigger event → same UUID.
- Background app > timeout or force-quit & relaunch past timeout → trigger event → new UUID.
- Confirm GA4 proxy receives correct 32-bit integer hash.

**Screenshots or screencasts (if UI/UX change)**
N/A – backend payload change only.

**Any background context you want to provide?**
No

**Questions**:

**Does the docs need an update?**
Yes – add sessionTimeout to the configuration section.

**Are there any security concerns?**
No PII stored; UUID remains local, hashed downstream.

****Do we need to update engineering / success?****
No.