### PR TITLE
FXSD-900 centralize session timeout constant & remove session_id injection from senData 

### DIFF
--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -572,7 +572,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
 - (NSString *)validatedSessionId
 {
-    NSTimeInterval timeout = self.state.configuration.sessionTimeout ?: 1800;
+    NSTimeInterval timeout = self.state.configuration.sessionTimeout;
     [self.state validateOrRenewSessionWithTimeout:timeout];
     
     return self.state.userInfo.sessionId;

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.m
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.m
@@ -31,6 +31,8 @@
 @end
 #endif
 
+static const NSTimeInterval DefaultSessionTimeout = 1800;
+
 @implementation FPAnalyticsExperimental
 @end
 
@@ -71,7 +73,7 @@
         self.payloadFilters = @{
             @"(fb\\d+://authorize#access_token=)([^ ]+)": @"$1((redacted/fb-auth-token))"
         };
-        self.sessionTimeout = 1800;
+        self.sessionTimeout = DefaultSessionTimeout;
         _factories = [NSMutableArray array];
 #if TARGET_OS_IPHONE
         if ([UIApplication respondsToSelector:@selector(sharedApplication)]) {

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -213,12 +213,12 @@ typedef _Nullable id (^FPStateGetBlock)(void);
 
 - (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout {
     NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
-    NSTimeInterval diff = now - self.userInfo.lastSessionTimestamp;
+    NSTimeInterval currentSessionDuration = now - self.userInfo.lastSessionTimestamp;
 
-    NSLog(@"[Session] now=%.0f, last=%.0f, diff=%.0f s, timeout=%.0f s",
-          now, self.userInfo.lastSessionTimestamp, diff, timeout);
+    NSLog(@"[Session] now=%.0f, last=%.0f, currentSessionDuration=%.0f s, timeout=%.0f s",
+          now, self.userInfo.lastSessionTimestamp, currentSessionDuration, timeout);
 
-    if (diff > timeout) {
+    if (currentSessionDuration > timeout) {
         self.userInfo.sessionId = GenerateUUIDString();
         self.userInfo.lastSessionTimestamp = now;
     }


### PR DESCRIPTION
- Introduced DefaultSessionTimeout to replace the hard-coded value throughout FPAnalyticsConfiguration.
- Removed $session_id mutation from sendData.
- Improve variable naming for session duration.