### PR TITLE
FXSD-900 unit tests

### DIFF
--- a/Freshpaint.xcodeproj/project.pbxproj
+++ b/Freshpaint.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		64FDB4D9257832BB001884FD /* FPStoreKitTracker.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 64FDB3B7256EE283001884FD /* FPStoreKitTracker.h */; };
 		64FDB4DA257832BB001884FD /* FPFileStorage.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 64FDB3BB256EE283001884FD /* FPFileStorage.h */; };
 		A3B6E29925116B3A00609A13 /* Freshpaint.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EADEB85B1DECD080005322DA /* Freshpaint.framework */; };
+		C31833C22DD7A44C00F2EE90 /* SessionTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C12DD7A44900F2EE90 /* SessionTimeoutTests.swift */; };
+		C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -293,6 +295,8 @@
 		64FDB486257831A7001884FD /* freshpaint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = freshpaint.h; sourceTree = "<group>"; };
 		64FDB487257831A7001884FD /* freshpaint.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = freshpaint.m; sourceTree = "<group>"; };
 		C31674B18CD818C64F8F3935 /* Pods_SegmentTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SegmentTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C31833C12DD7A44900F2EE90 /* SessionTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTimeoutTests.swift; sourceTree = "<group>"; };
+		C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdInjectionTests.swift; sourceTree = "<group>"; };
 		EADEB85B1DECD080005322DA /* Freshpaint.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Freshpaint.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EADEB86A1DECD0EF005322DA /* FreshpaintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FreshpaintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EADEB8FF1DED3711005322DA /* circle.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = circle.yml; sourceTree = "<group>"; };
@@ -423,6 +427,8 @@
 		64FDB442256F05A3001884FD /* FreshpaintTests */ = {
 			isa = PBXGroup;
 			children = (
+				C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */,
+				C31833C12DD7A44900F2EE90 /* SessionTimeoutTests.swift */,
 				64FDB443256F05A3001884FD /* TrackingTests.swift */,
 				644DF34C25A8FDF4000E5F2B /* FreshpaintTests-Bridging-Header.h */,
 				64FDB445256F05A3001884FD /* FreshpaintTests.swift */,
@@ -734,11 +740,13 @@
 			files = (
 				64FDB469256F05A4001884FD /* UserDefaultsStorageTest.swift in Sources */,
 				64FDB46A256F05A4001884FD /* AnalyticsUtilTests.swift in Sources */,
+				C31833C22DD7A44C00F2EE90 /* SessionTimeoutTests.swift in Sources */,
 				64FDB468256F05A3001884FD /* EndToEndTests.swift in Sources */,
 				644DF35625A8FF75000E5F2B /* NSData+FPGUNZPP.m in Sources */,
 				64FDB45B256F05A3001884FD /* TrackingTests.swift in Sources */,
 				64FDB45C256F05A3001884FD /* FreshpaintTests.swift in Sources */,
 				64FDB465256F05A3001884FD /* TestUtils.swift in Sources */,
+				C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */,
 				64FDB467256F05A3001884FD /* HTTPClientTest.swift in Sources */,
 				64FDB46C256F05A4001884FD /* FileStorageTest.swift in Sources */,
 				64FDB45D256F05A3001884FD /* StoreKitTrackerTests.swift in Sources */,

--- a/FreshpaintTests/AutoScreenReportingTest.swift
+++ b/FreshpaintTests/AutoScreenReportingTest.swift
@@ -61,7 +61,7 @@ class AutoScreenReportingTests: XCTestCase {
     }
     
     func testTopViewControllerReturnsCurrentSelectedViewController() {
-        class CustomContainerViewController: UIViewController, SEGScreenReporting {
+        class CustomContainerViewController: UIViewController, FPScreenReporting {
             var selectedIndex: Int = 0
             var seg_mainViewController: UIViewController? {
                 return children[selectedIndex]

--- a/FreshpaintTests/SessionIdInjectionTests.swift
+++ b/FreshpaintTests/SessionIdInjectionTests.swift
@@ -1,0 +1,142 @@
+//
+//  SessionIdInjectionTests.swift
+//  Freshpaint
+//
+//  Created by Miguel Vargas on 5/16/25.
+//  Copyright © 2025 Freshpaint. All rights reserved.
+//
+//  Tests
+//  -------
+//  1. Ensure the SDK injects a non-empty `$session_id` inside the
+//     `properties` dictionary before an event leaves the queue.
+//  2. Verify that a NEW `$session_id` is issued once the configured
+//     `sessionTimeout` expires.
+//  3. Confirm that, if a second event happens *within* the timeout
+//     window, the original `$session_id` is reused (and other keys are
+//     left intact).
+//
+
+import Freshpaint
+import XCTest
+
+class SessionIdInjectionTests: XCTestCase {
+
+    var passthrough: PassthroughMiddleware!
+    var analytics:   Freshpaint!
+    var configuration: FreshpaintConfiguration!
+
+    override func setUp() {
+        super.setUp()
+
+        configuration = FreshpaintConfiguration(writeKey: "3VxTfPsVOoEOSbbzzbFqVNcYMNu2vjnr")
+        configuration.flushAt       = 1    // flush immediately after 1 event
+        configuration.flushInterval = 0    // disable timer-based flush
+        configuration.sessionTimeout = 1   // 1-second timeout for tests
+
+        passthrough = PassthroughMiddleware()
+        configuration.sourceMiddleware = [passthrough]
+
+        analytics = Freshpaint(configuration: configuration)
+    }
+
+    override func tearDown() {
+        analytics.reset()
+        super.tearDown()
+    }
+    
+    /// Asserts that the *queued* payload contains a non-empty `$session_id`.
+    func testSessionIdIsInjectedInQueue() {
+        let exp = expectation(description: "$session_id present after queue")
+        
+        let cfg = FreshpaintConfiguration(writeKey: "QUI5ydwIGeFFTa1IvCBUhxL9PyW5B0jE")
+        cfg.flushAt       = 1         
+        cfg.flushInterval = 0
+        cfg.experimental.rawFreshpaintModificationBlock = { event in
+            if
+                let props = event["properties"] as? [String: Any],
+                let sid   = props["$session_id"] as? String,
+                !sid.isEmpty
+            {
+                exp.fulfill()
+            }
+            return event
+        }
+        
+        let analytics = Freshpaint(configuration: cfg)
+        analytics.track("session id test")
+        analytics.flush()               
+        
+        wait(for: [exp], timeout: 3.0)
+    }
+
+    /// Sends two events separated by *more* than `sessionTimeout`.
+    /// Expects a different `$session_id` on the second event.
+    func testSessionIdRenewsAfterTimeout() {
+        let exp = expectation(description: "second event carries new $session_id")
+        var firstSessionId: String?
+
+        configuration.experimental.rawFreshpaintModificationBlock = { event in
+            guard
+                let props = event["properties"] as? [String: Any],
+                let sid   = props["$session_id"] as? String
+            else { return event }
+
+            if firstSessionId == nil {
+                firstSessionId = sid // captured on first event
+            } else if sid != firstSessionId {    
+                exp.fulfill() // different → passes
+            }
+            return event
+        }
+
+        // First event
+        analytics.track("first event")
+        analytics.flush()
+
+        // Second event after the 1-second timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            self.analytics.track("second event after timeout")
+            self.analytics.flush()
+        }
+
+        wait(for: [exp], timeout: 3.0)
+    }
+
+    /// Sends two events *within* the same `sessionTimeout` window.
+    /// Expects both to share the SAME `$session_id`.
+    func testSessionIdPersistsWithinTimeout() {
+        // 1 s de timeout: enviamos el segundo evento a los 0,3 s.
+        configuration.sessionTimeout = 10
+
+        let exp = expectation(description: "second event keeps same $session_id")
+
+        var firstSessionId: String?
+
+        configuration.experimental.rawFreshpaintModificationBlock = { event in
+            guard
+                let props = event["properties"] as? [String: Any],
+                let sid   = props["$session_id"] as? String
+            else { return event }
+
+            if firstSessionId == nil {
+                firstSessionId = sid                   // captured on first event
+            } else if sid == firstSessionId {          // identical → passes
+                exp.fulfill()
+            }
+            return event
+        }
+
+        // First event
+        analytics.track("first event within timeout")
+        analytics.flush()
+
+        // Second event 0.3 s later (well inside the 1-second timeout)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.analytics.track("second event within timeout")
+            self.analytics.flush()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+    }
+
+}

--- a/FreshpaintTests/SessionTimeoutTests.swift
+++ b/FreshpaintTests/SessionTimeoutTests.swift
@@ -1,0 +1,29 @@
+//
+//  SessionTimeoutTests.swift
+//  Freshpaint
+//
+//  Created by Miguel Vargas on 5/16/25.
+//  Copyright © 2025 Freshpaint. All rights reserved.
+//
+
+import XCTest
+@testable import Freshpaint 
+
+/// Verifies that a new configuration picks up the default timeout (1800 s).
+final class SessionTimeoutTests: XCTestCase {
+
+    /// The configuration should default to 1 800 s (30 min)
+    func testDefaultSessionTimeout() {
+        let cfg = FreshpaintConfiguration(writeKey: "dummy-key")
+        XCTAssertEqual(cfg.sessionTimeout, 1_800,
+                       "sessionTimeout should default to 1800 s (kDefaultSessionTimeout)")
+    }
+
+    /// If the user sets a custom timeout, that value must be kept.
+    func testCustomSessionTimeoutOverridesDefault() {
+        let cfg = FreshpaintConfiguration(writeKey: "dummy-key")
+        cfg.sessionTimeout = 3_600   // 60 min
+        XCTAssertEqual(cfg.sessionTimeout, 3_600,
+                       "sessionTimeout should reflect the user-supplied value")
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 XC_ARGS := -project Freshpaint.xcodeproj GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
-IOS_XCARGS := $(XC_ARGS) -destination "platform=iOS Simulator,name=iPhone 11" -sdk iphonesimulator
+IOS_XCARGS := $(XC_ARGS) -destination "platform=iOS Simulator,name=iPhone 16" -sdk iphonesimulator
 TVOS_XCARGS := $(XC_ARGS) -destination "platform=tvOS Simulator,name=Apple TV"
 MACOS_XCARGS := $(XC_ARGS) -destination "platform=macOS"
 XC_BUILD_ARGS := -scheme Freshpaint ONLY_ACTIVE_ARCH=NO


### PR DESCRIPTION
Adds unit tests for session handling:

* **SessionTimeoutTests** – checks default (1800 s) and custom timeout values.
* **SessionIdInjectionTests** – verifies `$session_id` is added, persists within the timeout, and renews after it expires.
