### PR TITLE
FXSD-900 feat(session) Add first-event-in-session tracking flag

### DIFF
--- a/Freshpaint/Classes/FPAnalytics.h
+++ b/Freshpaint/Classes/FPAnalytics.h
@@ -218,7 +218,11 @@ NS_SWIFT_NAME(Freshpaint)
 /** Returns the registered device token of this device */
 - (NSString *)getDeviceToken;
 
+/** Returns the session ID of the current user. */
 - (NSString *)validatedSessionId;
+
+/** Returns whether this is the first event in the session */
+- (BOOL)isFirstEventInSession;
 
 @end
 

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -578,5 +578,15 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     return self.state.userInfo.sessionId;
 }
 
+- (BOOL)isFirstEventInSession
+{
+    NSTimeInterval timeout = self.state.configuration.sessionTimeout;
+    NSTimeInterval now     = [[NSDate date] timeIntervalSince1970];
+    NSTimeInterval lastSessionTimestamp  = self.state.userInfo.lastSessionTimestamp;
+    NSTimeInterval currentSessionDuration = now - lastSessionTimestamp;
+
+    return (lastSessionTimestamp == 0) || (currentSessionDuration > timeout);
+}
+
 
 @end

--- a/Freshpaint/Classes/FPFreshpaintIntegration.m
+++ b/Freshpaint/Classes/FPFreshpaintIntegration.m
@@ -280,12 +280,15 @@ NSUInteger const kFPBackgroundTaskInvalid = 0;
 
     [self dispatchBackground:^{
         // attach the session ID into the payload’s `properties` dictionary
+        BOOL isFirstEventInSession = [self.analytics isFirstEventInSession];
+
         NSString *sessionParameter = [self.analytics validatedSessionId];
 
         NSMutableDictionary *props = [payload[@"properties"] mutableCopy] ?: [NSMutableDictionary dictionary];
         
         props[@"$session_id"] = sessionParameter;
-        
+        props[@"$is_first_event_in_session"] = @(isFirstEventInSession);
+
         [payload setValue:[props copy] forKey:@"properties"];
 
         // attach userId and anonymousId inside the dispatch_async in case

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -192,7 +192,7 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         self.userInfo = [[FPUserInfo alloc] initWithState:self];
         self.context = [[FPPayloadContext alloc] initWithState:self];
         self.userInfo.sessionId = GenerateUUIDString();
-        self.userInfo.lastSessionTimestamp = [[NSDate date] timeIntervalSince1970];
+        self.userInfo.lastSessionTimestamp = 0;
     }
     return self;
 }
@@ -213,15 +213,17 @@ typedef _Nullable id (^FPStateGetBlock)(void);
 
 - (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout {
     NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
-    NSTimeInterval currentSessionDuration = now - self.userInfo.lastSessionTimestamp;
+    NSTimeInterval lastSessionTimestamp = self.userInfo.lastSessionTimestamp;
+    NSTimeInterval currentSessionDuration = now - lastSessionTimestamp;
 
-    NSLog(@"[Session] now=%.0f, last=%.0f, currentSessionDuration=%.0f s, timeout=%.0f s",
+    NSLog(@"[Session] now=%.3f, last=%.3f, currentSessionDuration=%.3f s, timeout=%.0f s",
           now, self.userInfo.lastSessionTimestamp, currentSessionDuration, timeout);
 
-    if (currentSessionDuration > timeout) {
+    if (lastSessionTimestamp == 0 || currentSessionDuration > timeout) {
         self.userInfo.sessionId = GenerateUUIDString();
         self.userInfo.lastSessionTimestamp = now;
     }
+
 }
 
 @end


### PR DESCRIPTION
This PR adds first-event-in-session tracking:

**isFirstEventInSession flag:** Introduces a method to detect the very first event of a session (cold-start or after timeout).

**Payload injection:** Updates the event enqueueing flow to inject $is_first_event_in_session flag into properties.

**Unit tests:** Adds tests to verify that:

The `$is_first_event_in_session` flag is true on the first event and false for subsequent events until the timeout elapses.