### PR TITLE
Add versioning questions to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
 **What does this PR do?**
 
+**Is this a version update?**
+- Did you update the Podspec?
+- Did you update the Changelog?
+- Did you add an updated Github tag that matches the version?
+
 **Where should the reviewer start?**
 
 **How should this be manually tested?**
@@ -11,6 +16,6 @@
 **Screenshots or screencasts (if UI/UX change)**
 
 **Questions:**
-- Does the docs need an update?
+- Do the docs need an update?
 - Are there any security concerns?
 - Do we need to update engineering / success?


### PR DESCRIPTION
The last two version bumps missed updating the Github tag to match the podspec. Adding these questions to PR template for now -- hoping to automate this tagging for future version upgrades.

See slack thread here for more details:
https://freshpaint-io.slack.com/archives/C01T4F9FWHY/p1758130685777529
