### PR TITLE
fix(ios): cache lowercaseToCanonical and document no-expiry policy [FRP-61]

### DIFF
--- a/Freshpaint/Classes/FPAdClickIds.h
+++ b/Freshpaint/Classes/FPAdClickIds.h
@@ -17,21 +17,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Extracts click IDs and UTM params from a URL after applying payload filters.
 ///
-/// Click IDs are stored without an expiry by design -- they represent one-time
+/// Click IDs are stored without an expiry by design — they represent one-time
 /// attribution signals that remain valid for the lifetime of the install. A TTL
 /// may be introduced if product requirements change. UTM parameters, by contrast,
 /// expire after 24 hours.
 ///
 /// @param url             The deep link URL to inspect.
-/// @param filters         Payload filter patterns (regex -> replacement) -- applied to the URL
+/// @param filters         Payload filter patterns (regex → replacement) — applied to the URL
 ///                        string before query parameter extraction.
 ///
 /// @return A dictionary with two keys:
-///   - @"clickIds"  : NSDictionary<NSString*, id> -- flat map of @"$key" -> value and
-///                    @"$key_creation_time" -> NSNumber (Unix timestamp in milliseconds).
+///   - @"clickIds"  : NSDictionary<NSString*, id> — flat map of @"$key" → value and
+///                    @"$key_creation_time" → NSNumber (Unix timestamp in milliseconds).
 ///                    Google gacid and Facebook extras are also included here.
 ///                    Empty dict when no click IDs are present.
-///   - @"utmParams" : NSDictionary<NSString*, NSString*> -- map of utm_* param -> value.
+///   - @"utmParams" : NSDictionary<NSString*, NSString*> — map of utm_* param → value.
 ///                    Empty dict when no UTM params are present.
 + (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
                                   payloadFilters:(NSDictionary<NSString *, NSString *> *)filters;

--- a/Freshpaint/Classes/FPAdClickIds.h
+++ b/Freshpaint/Classes/FPAdClickIds.h
@@ -17,16 +17,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Extracts click IDs and UTM params from a URL after applying payload filters.
 ///
+/// Click IDs are stored without an expiry by design -- they represent one-time
+/// attribution signals that remain valid for the lifetime of the install. A TTL
+/// may be introduced if product requirements change. UTM parameters, by contrast,
+/// expire after 24 hours.
+///
 /// @param url             The deep link URL to inspect.
-/// @param filters         Payload filter patterns (regex → replacement) — applied to the URL
+/// @param filters         Payload filter patterns (regex -> replacement) -- applied to the URL
 ///                        string before query parameter extraction.
 ///
 /// @return A dictionary with two keys:
-///   - @"clickIds"  : NSDictionary<NSString*, id> — flat map of @"$key" → value and
-///                    @"$key_creation_time" → NSNumber (Unix timestamp in milliseconds).
+///   - @"clickIds"  : NSDictionary<NSString*, id> -- flat map of @"$key" -> value and
+///                    @"$key_creation_time" -> NSNumber (Unix timestamp in milliseconds).
 ///                    Google gacid and Facebook extras are also included here.
 ///                    Empty dict when no click IDs are present.
-///   - @"utmParams" : NSDictionary<NSString*, NSString*> — map of utm_* param → value.
+///   - @"utmParams" : NSDictionary<NSString*, NSString*> -- map of utm_* param -> value.
 ///                    Empty dict when no UTM params are present.
 + (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
                                   payloadFilters:(NSDictionary<NSString *, NSString *> *)filters;

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -71,6 +71,7 @@
     // the later entry in supportedClickIdKeys wins the canonical slot. ScCid is
     // listed after sccid, so the canonical key is always $ScCid. The value stored
     // is from whichever URL query item appears first (first-URL-order wins for values).
+    // Cached once; dispatch_once blocks concurrent callers until init completes.
     static NSDictionary<NSString *, NSString *> *lowercaseToCanonical;
     static dispatch_once_t canonicalOnceToken;
     dispatch_once(&canonicalOnceToken, ^{

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -66,17 +66,21 @@
         }
     }
 
-    // Build a case-insensitive lookup set for the 24 canonical parameter names.
-    NSArray<NSString *> *supportedKeys = [self supportedClickIdKeys];
-    // Map lowercase → canonical key name for case-insensitive matching.
+    // Build a case-insensitive lookup from lowercase → canonical key name.
     // When two keys share the same lowercase form (sccid / ScCid for Snapchat),
     // the later entry in supportedClickIdKeys wins the canonical slot. ScCid is
     // listed after sccid, so the canonical key is always $ScCid. The value stored
     // is from whichever URL query item appears first (first-URL-order wins for values).
-    NSMutableDictionary<NSString *, NSString *> *lowercaseToCanonical = [NSMutableDictionary dictionary];
-    for (NSString *key in supportedKeys) {
-        lowercaseToCanonical[key.lowercaseString] = key;
-    }
+    static NSDictionary<NSString *, NSString *> *lowercaseToCanonical;
+    static dispatch_once_t canonicalOnceToken;
+    dispatch_once(&canonicalOnceToken, ^{
+        NSArray<NSString *> *keys = [self supportedClickIdKeys];
+        NSMutableDictionary<NSString *, NSString *> *map = [NSMutableDictionary dictionaryWithCapacity:keys.count];
+        for (NSString *key in keys) {
+            map[key.lowercaseString] = key;
+        }
+        lowercaseToCanonical = [map copy];
+    });
 
     NSURLComponents *components = [NSURLComponents componentsWithURL:filteredURL
                                              resolvingAgainstBaseURL:NO];


### PR DESCRIPTION
## Summary

Follow-up from PR #32 (FRP-38) code review addressing two remaining items:

- Cache the `lowercaseToCanonical` dictionary with `dispatch_once` in `extractFromURL:payloadFilters:` so the mapping is built once instead of on every call
- Add doc comment on `extractFromURL:payloadFilters:` documenting the intentional no-expiry policy for click IDs (unlike UTM params which expire after 24h)

The other three review items (header visibility change to Project, exact count assertion, `#if DEBUG` guard) were already addressed in the parent branch.

## Test plan

- [ ] Build the Freshpaint framework target -- verify `FPAdClickIds.h` does not appear in public headers
- [ ] Run existing tests: `xcodebuild test -scheme Freshpaint` -- all pass including `testAllClickIdKeysExtracted`
- [ ] Verify demo app builds in both Debug and Release schemes