### PR TITLE
refactor(att): address PR #30 review feedback [FRP-59]

### DIFF
--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -205,13 +205,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         NSUInteger (^statusProvider)(void) = objc_getAssociatedObject(
             self, @selector(fp_attStatusProvider));
         NSUInteger attStatus = statusProvider ? statusProvider() : [FPAnalytics trackingAuthorizationStatus];
-        NSString *attStatusStr;
-        switch (attStatus) {
-            case 1:  attStatusStr = @"restricted";    break;
-            case 2:  attStatusStr = @"denied";        break;
-            case 3:  attStatusStr = @"authorized";    break;
-            default: attStatusStr = @"notDetermined"; break;
-        }
+        NSString *attStatusStr = FPATTStatusToString(attStatus);
 
         NSMutableDictionary *installProps = [NSMutableDictionary dictionary];
         installProps[@"install_timestamp"] = iso8601FormattedString([NSDate date]);
@@ -221,7 +215,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         installProps[@"os_version"]        = [[UIDevice currentDevice] systemVersion] ?: @"";
         installProps[@"app_version"]       = currentVersion ?: @"";
 
-        if (attStatus == 3 && self.oneTimeConfiguration.adSupportBlock != nil) {
+        if (attStatus == kFPATTStatusAuthorized && self.oneTimeConfiguration.adSupportBlock != nil) {
             NSString *idfa = self.oneTimeConfiguration.adSupportBlock();
             if (idfa.length > 0 && ![idfa isEqualToString:kFPInstallZeroedIDFA]) {
                 installProps[@"idfa"] = idfa;
@@ -234,14 +228,11 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         // idfv, att_status, and idfa require UIDevice/ATT and are intentionally omitted.
         [self track:@"app_install" properties:@{
             @"install_timestamp" : iso8601FormattedString([NSDate date]),
+            @"device_id"         : [FPStableDeviceId deviceId],
             @"os_version"        : [NSProcessInfo processInfo].operatingSystemVersionString ?: @"",
             @"app_version"       : currentVersion ?: @"",
         }];
 #endif
-        // Guard: write the install flag immediately after enqueue so a subsequent
-        // cold launch after app-kill does not re-fire the event.
-        [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
-        [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     } else {
         // Returning user — fire Application Updated if the build changed.
         if (![currentBuild isEqualToString:previousBuildV2]) {
@@ -252,11 +243,14 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 @"build" : currentBuild ?: @"",
             }];
         }
-        // Write version keys for returning users. Fresh install already wrote these
-        // above (guard write immediately after app_install enqueue).
-        [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
-        [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     }
+
+    // Persist version/build for both fresh-install and returning-user paths.
+    // For fresh installs this acts as the guard flag so a subsequent cold launch
+    // after app-kill does not re-fire app_install. For returning users it keeps
+    // the stored values current for the next Application Updated comparison.
+    [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
 
 #if TARGET_OS_IPHONE
     [self track:@"Application Opened" properties:@{

--- a/Freshpaint/Classes/FPAttributionMiddleware.m
+++ b/Freshpaint/Classes/FPAttributionMiddleware.m
@@ -41,17 +41,6 @@ static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000"
     return FPATTGetCurrentStatus();
 }
 
-- (NSString *)attStatusStringForStatus:(NSUInteger)status
-{
-    if (status == kFPATTStatusUnavailable) return @"unavailable";
-    switch (status) {
-        case kFPATTStatusRestricted:    return @"restricted";
-        case kFPATTStatusDenied:        return @"denied";
-        case kFPATTStatusAuthorized:    return @"authorized";
-        default:                        return @"notDetermined"; // kFPATTStatusNotDetermined (0)
-    }
-}
-
 #pragma mark - FPMiddleware
 
 - (void)context:(FPContext *)context next:(FPMiddlewareNext)next
@@ -62,7 +51,7 @@ static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000"
         NSUInteger status = [self currentATTStatus];
         NSMutableDictionary *enrichment = [NSMutableDictionary dictionary];
 
-        enrichment[@"att_status"] = [self attStatusStringForStatus:status];
+        enrichment[@"att_status"] = FPATTStatusToString(status);
 
         // Include IDFA only when fully authorized and adSupportBlock is set.
         if (status == kFPATTStatusAuthorized && self.configuration.adSupportBlock != nil) {

--- a/Freshpaint/Internal/FPATTRuntime.h
+++ b/Freshpaint/Internal/FPATTRuntime.h
@@ -23,6 +23,22 @@ static const NSUInteger kFPATTStatusAuthorized    = 3;
 /// (notDetermined = 0) from "platform has no ATT framework".
 static const NSUInteger kFPATTStatusUnavailable = NSUIntegerMax;
 
+/// Returns a human-readable string for the given ATT authorization status value.
+///
+/// @param status  One of the kFPATTStatus* constants (0–3) or kFPATTStatusUnavailable.
+/// @return A string suitable for analytics payloads: "notDetermined", "restricted",
+///         "denied", "authorized", or "unavailable".
+static inline NSString *FPATTStatusToString(NSUInteger status)
+{
+    switch (status) {
+        case kFPATTStatusRestricted: return @"restricted";
+        case kFPATTStatusDenied:     return @"denied";
+        case kFPATTStatusAuthorized: return @"authorized";
+        case kFPATTStatusUnavailable: return @"unavailable";
+        default:                     return @"notDetermined";
+    }
+}
+
 /// Returns the current ATT tracking authorization status via runtime-only lookup.
 /// Never imports AppTrackingTransparency directly — safe for apps that omit it.
 ///

--- a/FreshpaintTests/FPATTAPITests.m
+++ b/FreshpaintTests/FPATTAPITests.m
@@ -240,7 +240,7 @@
 /// FPAttributionMiddleware uses NSUIntegerMax internally but that is not a public API concern.
 - (void)testTrackingAuthorizationStatusAndRequestCompletionAgreeOnUnavailable
 {
-    // Both public methods collapse kFPATTStatusUnavailable -> 0.
+    // Both public methods collapse kFPATTStatusUnavailable → 0.
     // Note: fp_attStatusProvider has no effect here because +trackingAuthorizationStatus
     // calls FPATTGetCurrentStatus(), a static inline function resolved at compile time.
     // The provider seam only affects instance methods that read the associated object.

--- a/FreshpaintTests/FPATTAPITests.m
+++ b/FreshpaintTests/FPATTAPITests.m
@@ -240,13 +240,12 @@
 /// FPAttributionMiddleware uses NSUIntegerMax internally but that is not a public API concern.
 - (void)testTrackingAuthorizationStatusAndRequestCompletionAgreeOnUnavailable
 {
-    // Both public methods collapse kFPATTStatusUnavailable → 0.
-    // Simulate unavailable via the provider seam and verify the public method returns 0.
+    // Both public methods collapse kFPATTStatusUnavailable -> 0.
+    // Note: fp_attStatusProvider has no effect here because +trackingAuthorizationStatus
+    // calls FPATTGetCurrentStatus(), a static inline function resolved at compile time.
+    // The provider seam only affects instance methods that read the associated object.
+    // We verify the contract by confirming the public class method stays within [0,3].
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTStatusUnavailable; };
-    // trackingAuthorizationStatus uses FPATTGetCurrentStatus() directly, not the provider.
-    // We verify the contract by reading the raw value and confirming the mapping.
-    // The actual runtime mapping lives in the +trackingAuthorizationStatus implementation.
     XCTAssertLessThanOrEqual([FPAnalytics trackingAuthorizationStatus], 3,
         @"+trackingAuthorizationStatus must stay within [0,3] — unavailable maps to 0");
 #endif

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -12,6 +12,11 @@
 #import "FPMiddleware.h"
 #import "FPContext.h"
 #import "FPTrackPayload.h"
+#import "FPATTTestConstants.h"
+
+// NSUserDefaults keys — defined in FPAnalytics.m, declared here for test access.
+extern NSString *const FPVersionKey;
+extern NSString *const FPBuildKeyV2;
 
 // ---------------------------------------------------------------------------
 #pragma mark - Test-only extensions
@@ -66,19 +71,11 @@
 @end
 
 // ---------------------------------------------------------------------------
-#pragma mark - ATT status constants
+#pragma mark - Test IDFA fixtures
 // ---------------------------------------------------------------------------
-
-static const NSUInteger kFPATTNotDetermined = 0;
-static const NSUInteger kFPATTDenied        = 2;
-static const NSUInteger kFPATTAuthorized    = 3;
 
 static NSString *const kFPValidIDFA  = @"12345678-1234-1234-1234-123456789ABC";
 static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
-
-// NSUserDefaults keys (match the constants defined in FPAnalytics.m)
-static NSString *const kFPBuildKeyV2  = @"FPBuildKeyV2";
-static NSString *const kFPVersionKey  = @"FPVersionKey";
 
 // ---------------------------------------------------------------------------
 #pragma mark - Test class
@@ -100,12 +97,12 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     [super setUp];
 
     // Persist original NSUserDefaults state so tearDown can restore it exactly.
-    self.savedBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
-    self.savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:kFPVersionKey];
+    self.savedBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2];
+    self.savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:FPVersionKey];
 
     // Simulate a fresh install by removing the guard flag.
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPBuildKeyV2];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPVersionKey];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPVersionKey];
 
     // Build a configuration that fires lifecycle events but does NOT hook into
     // UIApplication (no notifications registered — tests drive the method directly).
@@ -123,14 +120,14 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
     // Restore NSUserDefaults to the state before this test.
     if (self.savedBuildV2) {
-        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:kFPBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:FPBuildKeyV2];
     } else {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPBuildKeyV2];
     }
     if (self.savedVersion) {
-        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:kFPVersionKey];
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:FPVersionKey];
     } else {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPVersionKey];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPVersionKey];
     }
     [[NSUserDefaults standardUserDefaults] synchronize];
 
@@ -192,8 +189,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IOS
     // Seed the guard flag to simulate a returning user.
-    [[NSUserDefaults standardUserDefaults] setObject:@"1.0" forKey:kFPBuildKeyV2];
-    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:kFPVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1.0" forKey:FPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:FPVersionKey];
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
@@ -213,7 +210,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testPayloadContainsRequiredFields
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTNotDetermined; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTNotDetermined; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
@@ -265,7 +262,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAIncludedWhenATTAuthorized
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTAuthorized; };
     self.configuration.adSupportBlock   = ^NSString *{ return kFPValidIDFA; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -283,7 +280,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAAbsentWhenATTNotAuthorized
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTDenied; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTDenied; };
     self.configuration.adSupportBlock   = ^NSString *{ return kFPValidIDFA; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -301,7 +298,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAAbsentWhenAdSupportBlockNil
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTAuthorized; };
     // adSupportBlock intentionally not set — remains nil
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -319,7 +316,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAAbsentWhenZeroedIDFA
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTAuthorized; };
     self.configuration.adSupportBlock   = ^NSString *{ return kFPZeroIDFA; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -343,13 +340,13 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IOS
     // Guard: key must be absent before the call.
-    XCTAssertNil([[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2],
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2],
                  @"Pre-condition: FPBuildKeyV2 must be nil before first launch");
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     // No flush called — flag must already be set.
-    NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
+    NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2];
     XCTAssertNotNil(storedBuild,
                     @"FPBuildKeyV2 must be written immediately after app_install is enqueued, not deferred to flush");
 #else
@@ -366,8 +363,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IOS
     // Seed guard flag so this looks like a returning launch with an updated build.
-    [[NSUserDefaults standardUserDefaults] setObject:@"0.9" forKey:kFPBuildKeyV2];
-    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:kFPVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:@"0.9" forKey:FPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:FPVersionKey];
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 


### PR DESCRIPTION
## Summary

Addresses all 6 review items from PR #30:

- **Item 1**: Add `device_id` to macOS `app_install` payload via `FPStableDeviceId`
- **Item 2**: Add `FPATTStatusToString()` shared helper in `FPATTRuntime.h`, replacing duplicated status-to-string mapping in `FPAnalytics.m` and `FPAttributionMiddleware.m`
- **Item 3**: Hoist duplicated `NSUserDefaults` writes from both if/else branches into a single write after the block
- **Item 4**: `FPAttributionMiddleware+Testing.h` confirmed still actively used by `FPAttributionMiddlewareTests.m` -- no change needed
- **Item 5**: Replace magic numbers (`attStatus == 3`) with named constants (`kFPATTStatusAuthorized`); replace redefined test constants in `FPAppInstallEventTests` with imports from `FPATTTestConstants.h` and `extern` declarations
- **Item 6**: Remove misleading `fp_attStatusProvider` setup in `FPATTAPITests` that had no effect on the `+trackingAuthorizationStatus` class method (static inline, not mockable via provider)

## Files changed

| File | Items |
|------|-------|
| `Freshpaint/Internal/FPATTRuntime.h` | 2 |
| `Freshpaint/Classes/FPAnalytics.m` | 1, 2, 3, 5 |
| `Freshpaint/Classes/FPAttributionMiddleware.m` | 2 |
| `FreshpaintTests/FPAppInstallEventTests.m` | 5 |
| `FreshpaintTests/FPATTAPITests.m` | 6 |

## Test plan

- [ ] Build iOS target -- no new warnings/errors from changed files
- [ ] Build macOS target -- `FPStableDeviceId` resolves and `device_id` included in payload
- [ ] Run `FPAppInstallEventTests` -- all pass with shared constants
- [ ] Run `FPATTAPITests` -- all pass after removing misleading provider setup
- [ ] Run `FPAttributionMiddlewareTests` -- all pass with `FPATTStatusToString()`
- [ ] Verify no remaining magic numbers or duplicate ATT status mapping