### PR TITLE
feat(mmp): merge FRP-37/38/39 into mmp-integrations

### DIFF
--- a/Examples/FreshpaintDemo/FreshpaintDemo.xcodeproj/project.pbxproj
+++ b/Examples/FreshpaintDemo/FreshpaintDemo.xcodeproj/project.pbxproj
@@ -17,9 +17,22 @@
 		AD5E9P0R7F6A4B2C1D3E8F91 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		FADEBABE00001234ABCD5678 /* FreshpaintDemo */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 76CA4BE62E05BDC900AC6FAB /* FreshpaintDemo */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		76CA4BE92E05BDC900AC6FAB /* FreshpaintDemo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				FADEBABE00001234ABCD5678 /* FreshpaintDemo */,
+			);
 			path = FreshpaintDemo;
 			sourceTree = "<group>";
 		};
@@ -267,13 +280,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_NSUserTrackingUsageDescription = "Freshpaint uses this identifier to measure attribution and ad campaign performance.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = FreshpaintDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -297,13 +305,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSUserTrackingUsageDescription = "Freshpaint uses this identifier to measure attribution and ad campaign performance.";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = FreshpaintDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
@@ -30,7 +30,9 @@ class AttributionEventLog: ObservableObject {
 
 struct AttributionDemoView: View {
 
-    @StateObject private var eventLog = AttributionEventLog.shared
+    // @ObservedObject (not @StateObject) because the singleton's lifecycle is managed
+    // externally by AttributionEventLog.shared, not by this view's lifetime.
+    @ObservedObject private var eventLog = AttributionEventLog.shared
 
     private let tests: [(id: String, label: String, url: String)] = [
         ("T1",  "T1 — Regression (no click IDs)",
@@ -124,7 +126,7 @@ struct AttributionDemoView: View {
                         Spacer()
                         Button("Refresh") { refreshStoredIds() }.font(.caption2)
                         Button("Clear All") {
-                            UserDefaults.standard.removeObject(forKey: "com.freshpaint.clickIds")
+                            UserDefaults.standard.removeObject(forKey: "com.freshpaint.clickIds") // internal SDK key
                             UserDefaults.standard.synchronize()
                             refreshStoredIds()
                         }.font(.caption2).foregroundColor(.red)
@@ -191,6 +193,7 @@ struct AttributionDemoView: View {
     }
 
     private func refreshStoredIds() {
+        // NOTE: reads an internal SDK storage key — update here if FPState's key changes.
         guard let data = UserDefaults.standard.data(forKey: "com.freshpaint.clickIds"),
               let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
               !plist.isEmpty

--- a/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
@@ -2,414 +2,209 @@
 //  AttributionDemoView.swift
 //  FreshpaintDemo
 //
-//  Showcases the attribution features added in FRP-34 (stable device ID)
-//  and FRP-35/FRP-36 (ATT public API and attribution middleware).
+//  FRP-38 manual testing harness for deep link attribution.
 //
 
 import SwiftUI
-import UIKit
 import Freshpaint
 
+// ---------------------------------------------------------------------------
+// MARK: - Shared event log (populated by rawFreshpaintModificationBlock)
+// ---------------------------------------------------------------------------
+
+class AttributionEventLog: ObservableObject {
+    static let shared = AttributionEventLog()
+    @Published var entries: [String] = []
+
+    func append(_ entry: String) {
+        DispatchQueue.main.async {
+            self.entries.insert(entry, at: 0)
+            if self.entries.count > 50 { self.entries.removeLast() }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MARK: - AttributionDemoView
+// ---------------------------------------------------------------------------
+
 struct AttributionDemoView: View {
-    // MARK: - State
 
-    @State private var attStatus: UInt = 0
-    @State private var idfa: String = "Not available"
-    @State private var idfv: String = "Not available"
-    @State private var stableDeviceId: String = "Not available"
-    @State private var appVersion: String = "Not available"
-    @State private var isFirstLaunch: Bool = false
+    @StateObject private var eventLog = AttributionEventLog.shared
 
-    @State private var autoRequestSimEnabled = false
-    @State private var autoRequestLastResult: String = ""
+    private let tests: [(id: String, label: String, url: String)] = [
+        ("T1",  "T1 — Regression (no click IDs)",
+         "freshpaintdemo://open?ref=test"),
+        ("T2",  "T2 — Single gclid",
+         "freshpaintdemo://open?gclid=ABC123XYZ"),
+        ("T3",  "T3 — All 5 UTM params",
+         "freshpaintdemo://open?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale&utm_term=analytics&utm_content=banner"),
+        ("T4",  "T4 — Google gacid → campaign_id",
+         "freshpaintdemo://open?gclid=GCLID_VALUE&gacid=CAMPAIGN_456"),
+        ("T5",  "T5 — Facebook extras",
+         "freshpaintdemo://open?fbclid=FB123&ad_id=AD99&adset_id=ADSET77&campaign_id=CAMP55"),
+        ("T7a", "T7a — Dedup: first fire (msclkid)",
+         "freshpaintdemo://open?msclkid=BING_SAME_VALUE"),
+        ("T7b", "T7b — Dedup: second fire (same value)",
+         "freshpaintdemo://open?msclkid=BING_SAME_VALUE"),
+        ("T9",  "T9 — Multiple platforms",
+         "freshpaintdemo://open?gclid=G1&fbclid=FB2&ttclid=TT3&msclkid=MS4&twclid=TW5"),
+        ("T10", "T10 — No recognized params",
+         "freshpaintdemo://open?ref=homepage&section=deals"),
+    ]
 
-    @State private var testURL: String = "freshpaintdemo://test?fp_click_id=test123&utm_source=facebook&utm_campaign=summer"
-    @State private var lastDeepLinkURL: String = "None"
-    @State private var lastFpClickId: String = "null"
-    @State private var lastUtmSource: String = "null"
-    @State private var lastUtmCampaign: String = "null"
+    @State private var storedClickIds: String = ""
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 20) {
-                headerSection
-                deviceIdentifiersCard
-                attCard
-                autoRequestCard
-                deepLinkCard
-                attributionDataCard
-            }
-            .padding()
-        }
-        .navigationTitle("Attribution Demo")
-        .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            refresh()
-        }
-    }
+            VStack(spacing: 16) {
 
-    // MARK: - Header
+                // Header
+                VStack(spacing: 4) {
+                    Text("FRP-38 Attribution Tests")
+                        .font(.headline)
+                    Text("Tap a test → fires deep link + track event. Check 'Stored Click IDs' and 'Event Log' below.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
 
-    private var headerSection: some View {
-        VStack(spacing: 4) {
-            Text("Freshpaint Attribution Demo")
-                .font(.title2)
-                .fontWeight(.bold)
-
-            Text("Platform: iOS  |  First Launch: \(isFirstLaunch ? "Yes" : "No")")
-                .font(.caption)
-                .foregroundColor(.secondary)
-        }
-    }
-
-    // MARK: - Device Identifiers Card
-
-    private var deviceIdentifiersCard: some View {
-        CardView(title: "Device Identifiers") {
-            VStack(spacing: 12) {
-                AttributionRow(label: "Device ID", value: stableDeviceId)
-                AttributionRow(label: "IDFV", value: idfv)
-                AttributionRow(label: "IDFA", value: idfa)
-                AttributionRow(label: "ATT Status", value: attStatusString(attStatus))
-            }
-        }
-    }
-
-    // MARK: - ATT Card
-
-    private var attCard: some View {
-        CardView(title: "App Tracking Transparency (iOS)") {
-            Button("Request ATT Authorization") {
-                requestATT()
-            }
-            .foregroundColor(attStatus == 0 ? .blue : .secondary)
-            .disabled(attStatus != 0)
-            .frame(maxWidth: .infinity)
-        }
-    }
-
-    // MARK: - Auto-Request ATT Card
-
-    private var autoRequestCard: some View {
-        CardView(title: "Auto-Request ATT (FRP-36)") {
-            VStack(alignment: .leading, spacing: 14) {
-                Text("When autoRequestATT = YES, the SDK calls requestTrackingAuthorization automatically on every UIApplicationDidBecomeActiveNotification — but only when status is notDetermined. Subsequent foregrounds are no-ops once the user has responded.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                // Test buttons
+                VStack(spacing: 8) {
+                    ForEach(tests, id: \.id) { test in
+                        Button { runTest(test) } label: {
+                            HStack {
+                                Text(test.label).font(.caption).frame(maxWidth: .infinity, alignment: .leading)
+                                Image(systemName: "play.circle.fill").foregroundColor(.blue)
+                            }
+                            .padding(10)
+                            .background(Color(.secondarySystemBackground))
+                            .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
 
                 Divider()
 
-                Toggle("Simulate autoRequestATT = YES", isOn: $autoRequestSimEnabled)
-                    .font(.subheadline)
-
-                Button("Simulate app didBecomeActive") {
-                    simulateAutoRequest()
+                // T6 — persistence (requires manual app restart)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("T6 — Persistence Across Restart").font(.caption).fontWeight(.semibold)
+                    Text("1. Tap 'Store ttclid'  2. Stop app in Xcode  3. Re-run  4. Tap 'Refresh' — $ttclid must still be present")
+                        .font(.caption2).foregroundColor(.secondary)
+                    HStack(spacing: 10) {
+                        Button("Store ttclid") {
+                            fireDeepLink("freshpaintdemo://open?ttclid=TIKTOK_PERSIST_99")
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { refreshStoredIds() }
+                        }.buttonStyle(.bordered)
+                    }
                 }
-                .foregroundColor(autoRequestSimEnabled ? .blue : .secondary)
-                .disabled(!autoRequestSimEnabled)
-                .frame(maxWidth: .infinity)
 
-                if !autoRequestLastResult.isEmpty {
-                    Text(autoRequestLastResult)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                Divider()
+
+                // T8 — first install simulation
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("T8 — First-Install Simulation").font(.caption).fontWeight(.semibold)
+                    Text("1. Tap 'Clear Install Guard'  2. Stop + re-run app  3. app_install fires  4. If click IDs were stored, they are merged in")
+                        .font(.caption2).foregroundColor(.secondary)
+                    Button("Clear Install Guard (FPBuildKeyV2)") {
+                        UserDefaults.standard.removeObject(forKey: "FPBuildKeyV2")
+                        UserDefaults.standard.removeObject(forKey: "FPVersionKey")
+                        UserDefaults.standard.synchronize()
+                        AttributionEventLog.shared.append("T8: install guard cleared — restart app to trigger app_install")
+                    }.buttonStyle(.bordered).tint(.orange)
                 }
-            }
-        }
-    }
 
-    // MARK: - Deep Link Card
+                Divider()
 
-    private var deepLinkCard: some View {
-        CardView(title: "Deep Link Testing") {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Test URL:")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-
-                TextField("Deep link URL", text: $testURL)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.caption)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-
-                Button("Process Test Deep Link") {
-                    processDeepLink()
+                // Stored click IDs panel
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Stored Click IDs (NSUserDefaults)").font(.caption).fontWeight(.semibold)
+                        Spacer()
+                        Button("Refresh") { refreshStoredIds() }.font(.caption2)
+                        Button("Clear All") {
+                            UserDefaults.standard.removeObject(forKey: "com.freshpaint.clickIds")
+                            UserDefaults.standard.synchronize()
+                            refreshStoredIds()
+                        }.font(.caption2).foregroundColor(.red)
+                    }
+                    Text(storedClickIds.isEmpty ? "(none)" : storedClickIds)
+                        .font(.system(size: 10, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
                 }
-                .foregroundColor(.blue)
-                .frame(maxWidth: .infinity)
 
-                if lastDeepLinkURL != "None" {
-                    Divider()
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Last Deep Link:")
-                            .font(.caption)
-                            .fontWeight(.semibold)
-
-                        Text("URL: \(lastDeepLinkURL)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-
-                        Text("fp_click_id: \(lastFpClickId)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                // Event log panel
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Event Log").font(.caption).fontWeight(.semibold)
+                        Spacer()
+                        Button("Clear") { AttributionEventLog.shared.entries.removeAll() }.font(.caption2)
+                    }
+                    if eventLog.entries.isEmpty {
+                        Text("(no events yet — run a test)")
+                            .font(.caption2).foregroundColor(.secondary)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(.secondarySystemBackground))
+                            .cornerRadius(8)
+                    } else {
+                        ForEach(Array(eventLog.entries.enumerated()), id: \.offset) { _, entry in
+                            Text(entry)
+                                .font(.system(size: 10, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(8)
+                                .background(Color(.secondarySystemBackground))
+                                .cornerRadius(8)
+                        }
                     }
                 }
             }
+            .padding()
+        }
+        .navigationTitle("Attribution (FRP-38)")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { refreshStoredIds() }
+    }
+
+    // MARK: - Logic
+
+    private func runTest(_ test: (id: String, label: String, url: String)) {
+        // 1. Fire deep link (stores click IDs / UTM in FPState + NSUserDefaults)
+        fireDeepLink(test.url)
+
+        // 2. After the async barrier write completes, fire a track event.
+        //    The rawFreshpaintModificationBlock set in FreshpaintDemoApp will log the full payload.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            Freshpaint.shared().track("Attribution Test \(test.id)", properties: ["test_id": test.id])
+            refreshStoredIds()
         }
     }
 
-    // MARK: - Attribution Data Card
-
-    private var attributionDataCard: some View {
-        CardView(title: "Attribution Data") {
-            VStack(spacing: 12) {
-                Button("Refresh Attribution Data") {
-                    refresh()
-                }
-                .foregroundColor(.blue)
-                .frame(maxWidth: .infinity)
-
-                AttributionJSONBlock(fields: attributionFields)
-            }
-        }
-    }
-
-    // MARK: - Attribution fields
-
-    private var attributionFields: [(key: String, value: AttributionValue)] {
-        [
-            ("att_status",    .string(attStatusString(attStatus))),
-            ("idfv",          .string(idfv)),
-            ("app_version",   .string(appVersion)),
-            ("idfa",          .string(idfa)),
-            ("fp_click_id",   lastFpClickId == "null"    ? .null : .string(lastFpClickId)),
-            ("utm_source",    lastUtmSource == "null"    ? .null : .string(lastUtmSource)),
-            ("utm_campaign",  lastUtmCampaign == "null"  ? .null : .string(lastUtmCampaign)),
-            ("device_id",     .string(stableDeviceId)),
-            ("first_launch",  .bool(isFirstLaunch)),
-        ]
-    }
-
-    // MARK: - Actions
-
-    private func refresh() {
-        attStatus = Freshpaint.trackingAuthorizationStatus()
-        stableDeviceId = "Auto-enriched in event context"
-        idfv = UIDevice.current.identifierForVendor?.uuidString ?? "Not available"
-        idfa = Freshpaint.advertisingIdentifier() ?? "Not available"
-        appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
-
-        let sessionInfo = Freshpaint.shared().sessionInfo(forAction: "attribution_demo_view")
-        isFirstLaunch = (sessionInfo["isFirstEventInSession"] as? Bool) ?? false
-    }
-
-    private func requestATT() {
-        Freshpaint.requestTrackingAuthorization { newStatus in
-            attStatus = newStatus
-            idfa = Freshpaint.advertisingIdentifier() ?? "Not available"
-        }
-    }
-
-    /// Mirrors the logic in _handleDidBecomeActiveForATT to demonstrate
-    /// what autoRequestATT = YES does on each didBecomeActive firing.
-    private func simulateAutoRequest() {
-        let status = Freshpaint.trackingAuthorizationStatus()
-        if status == 0 {
-            autoRequestLastResult = "Status is notDetermined — requesting authorization..."
-            Freshpaint.requestTrackingAuthorization { newStatus in
-                attStatus = newStatus
-                idfa = Freshpaint.advertisingIdentifier() ?? "Not available"
-                autoRequestLastResult = "ATT prompt shown. Final status: \(attStatusString(newStatus))"
-            }
-        } else {
-            autoRequestLastResult = "Status already determined (\(attStatusString(status))) — prompt skipped. Duplicate prevention works correctly."
-        }
-    }
-
-    private func processDeepLink() {
-        guard let url = URL(string: testURL) else { return }
-
+    private func fireDeepLink(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
         Freshpaint.shared().open(url, options: [:])
-
-        lastDeepLinkURL = testURL
-        lastFpClickId    = urlQueryItem("fp_click_id",   from: url) ?? "null"
-        lastUtmSource    = urlQueryItem("utm_source",    from: url) ?? "null"
-        lastUtmCampaign  = urlQueryItem("utm_campaign",  from: url) ?? "null"
-
-        Freshpaint.shared().track("Deep Link Processed", properties: [
-            "url": testURL,
-            "fp_click_id": lastFpClickId,
-            "utm_source": lastUtmSource,
-            "utm_campaign": lastUtmCampaign,
-        ])
+        AttributionEventLog.shared.append("→ openURL: \(urlString)")
     }
 
-    // MARK: - Helpers
-
-    private func attStatusString(_ status: UInt) -> String {
-        switch status {
-        case 0: return "notDetermined"
-        case 1: return "restricted"
-        case 2: return "denied"
-        case 3: return "authorized"
-        default: return "unavailable"
+    private func refreshStoredIds() {
+        guard let data = UserDefaults.standard.data(forKey: "com.freshpaint.clickIds"),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+              !plist.isEmpty
+        else {
+            storedClickIds = "(none)"
+            return
         }
-    }
-
-    private func urlQueryItem(_ name: String, from url: URL) -> String? {
-        URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .queryItems?
-            .first(where: { $0.name == name })?
-            .value
-    }
-}
-
-// MARK: - Attribution value type
-
-enum AttributionValue {
-    case string(String)
-    case bool(Bool)
-    case null
-}
-
-// MARK: - JSON block view
-
-struct AttributionJSONBlock: View {
-    let fields: [(key: String, value: AttributionValue)]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("{")
-                .jsonBase()
-
-            ForEach(Array(fields.enumerated()), id: \.offset) { index, field in
-                HStack(alignment: .top, spacing: 0) {
-                    Text("  ")
-                        .jsonBase()
-                    Text("\"\(field.key)\"")
-                        .jsonKey()
-                    Text(": ")
-                        .jsonBase()
-                    valueText(field.value)
-                    if index < fields.count - 1 {
-                        Text(",")
-                            .jsonBase()
-                    }
-                }
-            }
-
-            Text("}")
-                .jsonBase()
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color(red: 0.11, green: 0.13, blue: 0.17))
-        )
-    }
-
-    @ViewBuilder
-    private func valueText(_ value: AttributionValue) -> some View {
-        switch value {
-        case .string(let s):
-            Text("\"\(s)\"")
-                .jsonString()
-        case .bool(let b):
-            Text(b ? "true" : "false")
-                .jsonBool()
-        case .null:
-            Text("null")
-                .jsonNull()
-        }
-    }
-}
-
-// MARK: - JSON text modifiers
-
-private extension Text {
-    func jsonBase() -> some View {
-        self.font(.system(.caption, design: .monospaced))
-            .foregroundColor(Color(red: 0.75, green: 0.78, blue: 0.82))
-    }
-
-    func jsonKey() -> some View {
-        self.font(.system(.caption, design: .monospaced))
-            .foregroundColor(Color(red: 0.53, green: 0.81, blue: 0.98))
-    }
-
-    func jsonString() -> some View {
-        self.font(.system(.caption, design: .monospaced))
-            .foregroundColor(Color(red: 0.98, green: 0.73, blue: 0.44))
-            .lineLimit(2)
-            .minimumScaleFactor(0.8)
-    }
-
-    func jsonBool() -> some View {
-        self.font(.system(.caption, design: .monospaced))
-            .foregroundColor(Color(red: 0.82, green: 0.6, blue: 0.95))
-    }
-
-    func jsonNull() -> some View {
-        self.font(.system(.caption, design: .monospaced))
-            .foregroundColor(Color(red: 0.65, green: 0.65, blue: 0.65))
-    }
-}
-
-// MARK: - Reusable Card
-
-struct CardView<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: () -> Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.headline)
-                .fontWeight(.semibold)
-
-            content()
-        }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color(.systemBackground))
-                .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
-        )
-    }
-}
-
-// MARK: - Attribution Row
-
-struct AttributionRow: View {
-    let label: String
-    let value: String
-
-    var body: some View {
-        HStack(alignment: .top) {
-            Text("\(label):")
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                .frame(width: 90, alignment: .leading)
-
-            Text(value)
-                .font(.subheadline)
-                .fontWeight(.medium)
-                .lineLimit(2)
-                .minimumScaleFactor(0.7)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-        }
+        storedClickIds = plist
+            .sorted { $0.key < $1.key }
+            .map { k, v in "\(k): \(v)" }
+            .joined(separator: "\n")
     }
 }
 
 #Preview {
-    NavigationView {
-        AttributionDemoView()
-    }
+    NavigationView { AttributionDemoView() }
 }

--- a/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
@@ -63,7 +63,7 @@ struct ContentView: View {
                 AttributionDemoView()
             }
             .tabItem {
-                Image(systemName: "antenna.radiowaves.left.and.right")
+                Image(systemName: "link.badge.plus")
                 Text("Attribution")
             }
             .tag(3)

--- a/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
@@ -67,6 +67,16 @@ struct ContentView: View {
                 Text("Attribution")
             }
             .tag(3)
+
+            // Deep Link Tests Tab
+            NavigationView {
+                DeepLinkTestView()
+            }
+            .tabItem {
+                Image(systemName: "checklist")
+                Text("Deep Links")
+            }
+            .tag(4)
         }
         .sheet(isPresented: $showingDebugView) {
             DebugLogView(logs: debugLogs)

--- a/Examples/FreshpaintDemo/FreshpaintDemo/DeepLinkTestView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/DeepLinkTestView.swift
@@ -1,0 +1,470 @@
+//
+//  DeepLinkTestView.swift
+//  FreshpaintDemo
+//
+//  FRP-38: Comprehensive deep link attribution test harness.
+//  Covers all 24 supported click ID platforms + UTM params + persistence + dedup.
+//
+
+import SwiftUI
+import Freshpaint
+
+// ---------------------------------------------------------------------------
+// MARK: - Shared event log (populated by rawFreshpaintModificationBlock)
+// ---------------------------------------------------------------------------
+
+// NOTE: AttributionEventLog is defined in AttributionDemoView.swift.
+// Both views share the same singleton.
+
+// ---------------------------------------------------------------------------
+// MARK: - DeepLinkTestView
+// ---------------------------------------------------------------------------
+
+struct DeepLinkTestView: View {
+
+    // MARK: - Platform model
+
+    struct Platform: Identifiable {
+        let id: String          // URL param name, used as stable identity
+        let name: String        // Human-readable platform name
+        let urlParam: String    // Query param added to the deep link URL
+        let storedKey: String   // Key expected in NSUserDefaults click ID dict (e.g. "$gclid")
+        let extraParams: String? // Additional URL params required for this platform
+    }
+
+    enum TestStatus { case idle, pass, fail }
+
+    // MARK: - All 24 supported platforms
+
+    static let allPlatforms: [Platform] = [
+        Platform(id: "aleid",          name: "AppLovin",            urlParam: "aleid",          storedKey: "$aleid",          extraParams: nil),
+        Platform(id: "cntr_auctionId", name: "Basis",               urlParam: "cntr_auctionId", storedKey: "$cntr_auctionId", extraParams: nil),
+        Platform(id: "msclkid",        name: "Bing",                urlParam: "msclkid",        storedKey: "$msclkid",        extraParams: nil),
+        Platform(id: "fbclid",         name: "Facebook",            urlParam: "fbclid",         storedKey: "$fbclid",         extraParams: "ad_id=AD001&adset_id=ADSET001&campaign_id=CAMP001"),
+        Platform(id: "gclid",          name: "Google (gclid)",      urlParam: "gclid",          storedKey: "$gclid",          extraParams: "gacid=GCAMPAIGN001"),
+        Platform(id: "dclid",          name: "Google Display",      urlParam: "dclid",          storedKey: "$dclid",          extraParams: nil),
+        Platform(id: "gclsrc",         name: "Google cross-acct",   urlParam: "gclsrc",         storedKey: "$gclsrc",         extraParams: nil),
+        Platform(id: "wbraid",         name: "Google (wbraid)",     urlParam: "wbraid",         storedKey: "$wbraid",         extraParams: nil),
+        Platform(id: "gbraid",         name: "Google (gbraid)",     urlParam: "gbraid",         storedKey: "$gbraid",         extraParams: nil),
+        Platform(id: "irclickid",      name: "impact.com",          urlParam: "irclickid",      storedKey: "$irclickid",      extraParams: nil),
+        Platform(id: "li_fat_id",      name: "LinkedIn",            urlParam: "li_fat_id",      storedKey: "$li_fat_id",      extraParams: nil),
+        Platform(id: "ndclid",         name: "Nextdoor",            urlParam: "ndclid",         storedKey: "$ndclid",         extraParams: nil),
+        Platform(id: "epik",           name: "Pinterest",           urlParam: "epik",           storedKey: "$epik",           extraParams: nil),
+        Platform(id: "rdt_cid",        name: "Reddit",              urlParam: "rdt_cid",        storedKey: "$rdt_cid",        extraParams: nil),
+        Platform(id: "ScCid",          name: "Snapchat",            urlParam: "ScCid",          storedKey: "$ScCid",          extraParams: nil),
+        Platform(id: "spclid",         name: "Spotify",             urlParam: "spclid",         storedKey: "$spclid",         extraParams: nil),
+        Platform(id: "sapid",          name: "StackAdapt",          urlParam: "sapid",          storedKey: "$sapid",          extraParams: nil),
+        Platform(id: "ttdimp",         name: "TheTradeDesk",        urlParam: "ttdimp",         storedKey: "$ttdimp",         extraParams: nil),
+        Platform(id: "ttclid",         name: "TikTok",              urlParam: "ttclid",         storedKey: "$ttclid",         extraParams: nil),
+        Platform(id: "twclid",         name: "Twitter/X",           urlParam: "twclid",         storedKey: "$twclid",         extraParams: nil),
+        Platform(id: "clid_src",       name: "Twitter/X (alt)",     urlParam: "clid_src",       storedKey: "$clid_src",       extraParams: nil),
+        Platform(id: "viant_clid",     name: "Viant",               urlParam: "viant_clid",     storedKey: "$viant_clid",     extraParams: nil),
+        Platform(id: "qclid",          name: "Quora",               urlParam: "qclid",          storedKey: "$qclid",          extraParams: nil),
+    ]
+
+    // MARK: - State
+
+    @State private var results: [String: TestStatus] = [:]
+    @State private var storedClickIds: [String: Any] = [:]
+    @State private var storedUTM: [String: String] = [:]
+    @State private var utmResult: TestStatus = .idle
+    @State private var dedupResult: TestStatus = .idle
+    @State private var log: [String] = []
+    @State private var isRunningAll = false
+
+    // How many platforms have been tested (pass or fail)
+    private var testedCount: Int { results.values.filter { $0 != .idle }.count }
+    private var passCount:   Int { results.values.filter { $0 == .pass }.count }
+    private var allPlatforms: [Platform] { Self.allPlatforms }
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                summaryBanner
+                controlsRow
+                platformsSection
+                utmSection
+                dedupSection
+                persistenceNote
+                logSection
+            }
+            .padding()
+        }
+        .navigationTitle("Deep Link Tests")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { refreshState() }
+    }
+
+    // MARK: - Summary banner
+
+    private var summaryBanner: some View {
+        VStack(spacing: 6) {
+            Text("All 24 Ad Platforms")
+                .font(.headline)
+            HStack(spacing: 16) {
+                Label("\(passCount) passed", systemImage: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                Label("\(testedCount - passCount) failed", systemImage: "xmark.circle.fill")
+                    .foregroundColor(.red)
+                Label("\(allPlatforms.count - testedCount) pending", systemImage: "circle")
+                    .foregroundColor(.secondary)
+            }
+            .font(.caption)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Controls
+
+    private var controlsRow: some View {
+        HStack(spacing: 12) {
+            Button {
+                runAll()
+            } label: {
+                Label(isRunningAll ? "Running…" : "Run All 24", systemImage: "play.fill")
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isRunningAll)
+
+            Button {
+                resetAll()
+            } label: {
+                Label("Reset", systemImage: "trash")
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.red)
+        }
+    }
+
+    // MARK: - Platform rows
+
+    private var platformsSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Click ID Platforms")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+
+            ForEach(Self.allPlatforms) { platform in
+                platformRow(platform)
+            }
+        }
+    }
+
+    private func platformRow(_ platform: Platform) -> some View {
+        HStack {
+            // Status indicator
+            statusIcon(results[platform.id] ?? .idle)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(platform.name)
+                    .font(.subheadline)
+                if let stored = storedClickIds[platform.storedKey] {
+                    Text("\(platform.storedKey) = \(stored)")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                } else {
+                    Text(platform.storedKey)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary.opacity(0.5))
+                }
+            }
+
+            Spacer()
+
+            Button("Run") { runPlatform(platform) }
+                .font(.caption)
+                .buttonStyle(.bordered)
+                .disabled(isRunningAll)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 10)
+        .background(rowBackground(results[platform.id] ?? .idle))
+        .cornerRadius(8)
+    }
+
+    // MARK: - UTM section
+
+    private var utmSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                statusIcon(utmResult)
+                Text("UTM Parameters (all 5)")
+                    .font(.subheadline).fontWeight(.medium)
+                Spacer()
+                Button("Run") { runUTMTest() }
+                    .font(.caption).buttonStyle(.bordered)
+                    .disabled(isRunningAll)
+            }
+
+            if !storedUTM.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(storedUTM.sorted(by: { $0.key < $1.key })), id: \.key) { key, value in
+                        Text("\(key) = \(value)")
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.tertiarySystemBackground))
+                .cornerRadius(6)
+            }
+        }
+        .padding(12)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Dedup section
+
+    private var dedupSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                statusIcon(dedupResult)
+                Text("Deduplication (same value preserves creation_time)")
+                    .font(.subheadline).fontWeight(.medium)
+                Spacer()
+                Button("Run") { runDedupTest() }
+                    .font(.caption).buttonStyle(.bordered)
+                    .disabled(isRunningAll)
+            }
+            Text("Fires msclkid=DEDUP_TEST twice. The second fire must not update _creation_time.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Persistence note
+
+    private var persistenceNote: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Persistence (manual)", systemImage: "externaldrive.badge.checkmark")
+                .font(.subheadline).fontWeight(.medium)
+            Text("After running any test above, stop the app in Xcode and re-run. All click IDs marked ✅ should still show their stored values — they survive app kills via NSUserDefaults.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            Text("UTM params survive up to 24 hours; re-running after > 24h will clear them.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Log section
+
+    private var logSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Event Log").font(.caption).fontWeight(.semibold)
+                Spacer()
+                Button("Clear") {
+                    log.removeAll()
+                    AttributionEventLog.shared.entries.removeAll()
+                }
+                .font(.caption2)
+            }
+
+            if log.isEmpty {
+                Text("(run a test to see output)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.tertiarySystemBackground))
+                    .cornerRadius(6)
+            } else {
+                ForEach(Array(log.enumerated().reversed()), id: \.offset) { _, entry in
+                    Text(entry)
+                        .font(.system(size: 10, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(6)
+                        .background(Color(.tertiarySystemBackground))
+                        .cornerRadius(6)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers: visual
+
+    @ViewBuilder
+    private func statusIcon(_ status: TestStatus) -> some View {
+        switch status {
+        case .idle: Image(systemName: "circle").foregroundColor(.secondary)
+        case .pass: Image(systemName: "checkmark.circle.fill").foregroundColor(.green)
+        case .fail: Image(systemName: "xmark.circle.fill").foregroundColor(.red)
+        }
+    }
+
+    private func rowBackground(_ status: TestStatus) -> Color {
+        switch status {
+        case .idle: return Color(.tertiarySystemBackground)
+        case .pass: return Color.green.opacity(0.08)
+        case .fail: return Color.red.opacity(0.08)
+        }
+    }
+
+    // MARK: - Test actions
+
+    private func runPlatform(_ platform: Platform, value: String? = nil) {
+        let testValue = value ?? "TEST_\(platform.id.uppercased())_\(Int.random(in: 1000...9999))"
+        var urlStr = "freshpaintdemo://open?\(platform.urlParam)=\(testValue)"
+        if let extras = platform.extraParams { urlStr += "&\(extras)" }
+        guard let url = URL(string: urlStr) else { return }
+
+        Freshpaint.shared().open(url, options: [:])
+        appendLog("→ [\(platform.name)] \(urlStr)")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            refreshState()
+            let found = storedClickIds[platform.storedKey] != nil
+            results[platform.id] = found ? .pass : .fail
+            appendLog(found
+                ? "✅ \(platform.name): \(platform.storedKey) = \(storedClickIds[platform.storedKey]!)"
+                : "❌ \(platform.name): \(platform.storedKey) not found in stored click IDs")
+        }
+    }
+
+    private func runUTMTest() {
+        let urlStr = "freshpaintdemo://open?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale&utm_term=ios_sdk&utm_content=deeplink_test"
+        guard let url = URL(string: urlStr) else { return }
+        Freshpaint.shared().open(url, options: [:])
+        appendLog("→ [UTM] \(urlStr)")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            refreshStoredUTM()
+            let allPresent = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]
+                .allSatisfy { storedUTM[$0] != nil }
+            utmResult = allPresent ? .pass : .fail
+            appendLog(allPresent ? "✅ All 5 UTM params stored" : "❌ Some UTM params missing: \(storedUTM)")
+        }
+    }
+
+    private func runDedupTest() {
+        let firstURL  = URL(string: "freshpaintdemo://open?msclkid=DEDUP_TEST")!
+        let secondURL = URL(string: "freshpaintdemo://open?msclkid=DEDUP_TEST")!
+
+        Freshpaint.shared().open(firstURL, options: [:])
+        appendLog("→ [Dedup] Fire 1: msclkid=DEDUP_TEST")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            refreshState()
+            let creationTime1 = storedClickIds["$msclkid_creation_time"]
+
+            Freshpaint.shared().open(secondURL, options: [:])
+            appendLog("→ [Dedup] Fire 2: msclkid=DEDUP_TEST (same value)")
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                refreshState()
+                let creationTime2 = storedClickIds["$msclkid_creation_time"]
+                // Same value → creation_time must NOT change.
+                let preserved = (creationTime1 as? NSNumber) == (creationTime2 as? NSNumber)
+                dedupResult = preserved ? .pass : .fail
+                appendLog(preserved
+                    ? "✅ Dedup: creation_time preserved on second fire (\(creationTime1 ?? "?"))"
+                    : "❌ Dedup: creation_time changed — \(creationTime1 ?? "?") → \(creationTime2 ?? "?")")
+            }
+        }
+    }
+
+    private func runAll() {
+        isRunningAll = true
+        resetAll()
+        appendLog("▶ Running all 24 platforms + UTM + dedup…")
+
+        // Run platforms sequentially with 0.7s spacing to avoid state-queue contention.
+        let platforms = Self.allPlatforms
+        for (index, platform) in platforms.enumerated() {
+            let delay = Double(index) * 0.7
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                runPlatform(platform, value: "RUNALL_\(platform.id.uppercased())")
+            }
+        }
+
+        // UTM test after all platforms
+        let utmDelay = Double(platforms.count) * 0.7
+        DispatchQueue.main.asyncAfter(deadline: .now() + utmDelay) {
+            runUTMTest()
+        }
+
+        // Dedup test after UTM
+        let dedupDelay = utmDelay + 1.2
+        DispatchQueue.main.asyncAfter(deadline: .now() + dedupDelay) {
+            runDedupTest()
+        }
+
+        // Mark complete
+        let doneDelay = dedupDelay + 2.0
+        DispatchQueue.main.asyncAfter(deadline: .now() + doneDelay) {
+            isRunningAll = false
+            appendLog("✔ Run complete — \(passCount)/\(allPlatforms.count) platforms passed")
+        }
+    }
+
+    private func resetAll() {
+        results.removeAll()
+        utmResult = .idle
+        dedupResult = .idle
+        // NOTE: reads internal SDK keys — update here if FPState's storage keys change.
+        UserDefaults.standard.removeObject(forKey: "com.freshpaint.clickIds")
+        UserDefaults.standard.removeObject(forKey: "com.freshpaint.utmParams")
+        UserDefaults.standard.removeObject(forKey: "com.freshpaint.utmExpiry")
+        refreshState()
+        appendLog("🗑 State cleared")
+    }
+
+    // MARK: - State refresh
+
+    private func refreshState() {
+        refreshStoredClickIds()
+        refreshStoredUTM()
+    }
+
+    private func refreshStoredClickIds() {
+        // NOTE: reads an internal SDK key — update if FPState's storage key changes.
+        guard let data = UserDefaults.standard.data(forKey: "com.freshpaint.clickIds"),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        else {
+            storedClickIds = [:]
+            return
+        }
+        storedClickIds = plist
+    }
+
+    private func refreshStoredUTM() {
+        // NOTE: reads an internal SDK key — update if FPState's storage key changes.
+        guard let data = UserDefaults.standard.data(forKey: "com.freshpaint.utmParams"),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: String]
+        else {
+            storedUTM = [:]
+            return
+        }
+        storedUTM = plist
+    }
+
+    private func appendLog(_ message: String) {
+        let ts = DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .medium)
+        log.append("[\(ts)] \(message)")
+        if log.count > 100 { log.removeFirst() }
+    }
+}
+
+#Preview {
+    NavigationView { DeepLinkTestView() }
+}

--- a/Examples/FreshpaintDemo/FreshpaintDemo/FreshpaintDemoApp.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/FreshpaintDemoApp.swift
@@ -41,7 +41,25 @@ struct FreshpaintDemoApp: App {
         #if DEBUG
         Freshpaint.debug(true)
         #endif
-        
+
+        // FRP-38 testing: capture raw outgoing payloads and display attribution keys in the UI.
+        config.experimental.rawFreshpaintModificationBlock = { payload in
+            if let event = payload["event"] as? String {
+                let ctx = payload["context"] as? [String: Any] ?? [:]
+                let attrKeys = ctx.keys.filter { $0.hasPrefix("$") || $0.hasPrefix("utm_") }.sorted()
+                var line = "EVENT: \(event)"
+                if attrKeys.isEmpty {
+                    line += "\n  [no click IDs / UTM in context]"
+                } else {
+                    for k in attrKeys {
+                        line += "\n  \(k) = \(ctx[k] ?? "(nil)")"
+                    }
+                }
+                AttributionEventLog.shared.append(line)
+            }
+            return payload
+        }
+
         Freshpaint.setup(with: config)
     }
     
@@ -60,6 +78,9 @@ struct FreshpaintDemoApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onOpenURL { url in
+                    Freshpaint.shared().open(url, options: [:])
+                }
         }
     }
 }

--- a/Examples/FreshpaintDemo/FreshpaintDemo/FreshpaintDemoApp.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/FreshpaintDemoApp.swift
@@ -37,12 +37,11 @@ struct FreshpaintDemoApp: App {
         config.trackPushNotifications = true
         config.trackDeepLinks = true
         
-        // Enable debug logging for development
+        // Enable debug logging and FRP-38 attribution UI in development only.
         #if DEBUG
         Freshpaint.debug(true)
-        #endif
 
-        // FRP-38 testing: capture raw outgoing payloads and display attribution keys in the UI.
+        // Capture raw outgoing payloads and display attribution keys in the UI.
         config.experimental.rawFreshpaintModificationBlock = { payload in
             if let event = payload["event"] as? String {
                 let ctx = payload["context"] as? [String: Any] ?? [:]
@@ -59,6 +58,7 @@ struct FreshpaintDemoApp: App {
             }
             return payload
         }
+        #endif
 
         Freshpaint.setup(with: config)
     }

--- a/Examples/FreshpaintDemo/FreshpaintDemo/Info.plist
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+
+	<!-- Custom URL scheme: freshpaintdemo://
+	     Allows simulator testing via: xcrun simctl openurl booted "freshpaintdemo://open?gclid=ABC"
+	     and from the iOS Share Sheet / Safari address bar. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.freshpaint.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>freshpaintdemo</string>
+			</array>
+		</dict>
+	</array>
+
+	<!-- Scene manifest (required for SwiftUI @main apps) -->
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+
+	<!-- Launch screen -->
+	<key>UILaunchScreen</key>
+	<dict/>
+
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Freshpaint uses this identifier to measure attribution and ad campaign performance.</string>
+</dict>
+</plist>

--- a/Freshpaint.xcodeproj/project.pbxproj
+++ b/Freshpaint.xcodeproj/project.pbxproj
@@ -154,6 +154,9 @@
 		C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */; };
 		F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */; };
 		F54F79ED3362F50D0E40A8D7 /* FPStableDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = 21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */; };
+		D4E5F6A7B8C9D0E1F2A3B4C5 /* FPAdClickIds.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* FPAdClickIds.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E5F6A7B8C9D0E1F2A3B4C5D6 /* FPAdClickIds.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A3 /* FPAdClickIds.m */; };
+		F6A7B8C9D0E1F2A3B4C5D6E7 /* FPDeepLinkAttributionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F2A3B4 /* FPDeepLinkAttributionTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -309,7 +312,10 @@
 		264F73BDFE32CD69D92391CB /* FPATTRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = FPATTRuntime.h; sourceTree = "<group>"; };
 		59ECC4379B2D4AEF8B1FF16D /* FPATTTestConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = FPATTTestConstants.h; sourceTree = "<group>"; };
 		B38969724D688583AF3FBFD8 /* FPPayload+FPAttributionEnrichment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FPPayload+FPAttributionEnrichment.h"; sourceTree = "<group>"; };
-		BDD3ABE52729806D167C3AB3 /* FPStableDeviceIdTests.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; includeInIndex = 1; path = FPStableDeviceIdTests.m; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* FPAdClickIds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FPAdClickIds.h; sourceTree = "<group>"; };
+		B2C3D4E5F6A7B8C9D0E1F2A3 /* FPAdClickIds.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FPAdClickIds.m; sourceTree = "<group>"; };
+		C3D4E5F6A7B8C9D0E1F2A3B4 /* FPDeepLinkAttributionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPDeepLinkAttributionTests.m; sourceTree = "<group>"; };
+		BDD3ABE52729806D167C3AB3 /* FPStableDeviceIdTests.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPStableDeviceIdTests.m; sourceTree = "<group>"; };
 		C31674B18CD818C64F8F3935 /* Pods_SegmentTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SegmentTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C31833C12DD7A44900F2EE90 /* SessionTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTimeoutTests.swift; sourceTree = "<group>"; };
 		C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdInjectionTests.swift; sourceTree = "<group>"; };
@@ -411,6 +417,8 @@
 				64FDB3A5256EE283001884FD /* FPHTTPClient.h */,
 				FD103F0B18245918A82F733C /* FPAttributionMiddleware.h */,
 				8D5F0B5BE182A223FDBD6A25 /* FPAttributionMiddleware.m */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* FPAdClickIds.h */,
+				B2C3D4E5F6A7B8C9D0E1F2A3 /* FPAdClickIds.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -476,6 +484,7 @@
 				5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */,
 				A1B2C3D4E5F6789012345678 /* FPAttributionMiddleware+Testing.h */,
 				59ECC4379B2D4AEF8B1FF16D /* FPATTTestConstants.h */,
+				C3D4E5F6A7B8C9D0E1F2A3B4 /* FPDeepLinkAttributionTests.m */,
 			);
 			path = FreshpaintTests;
 			sourceTree = "<group>";
@@ -577,6 +586,7 @@
 				204F34B08E432CC775EF391D /* FPAttributionMiddleware.h in Headers */,
 				3DCAF6C056067280EBDFD6E3 /* FPPayload+FPAttributionEnrichment.h in Headers */,
 				A9406C83AEB727F546DDFA8F /* FPATTRuntime.h in Headers */,
+				D4E5F6A7B8C9D0E1F2A3B4C5 /* FPAdClickIds.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -764,6 +774,7 @@
 				64FDB3F1256EE283001884FD /* FPAES256Crypto.m in Sources */,
 				F54F79ED3362F50D0E40A8D7 /* FPStableDeviceId.m in Sources */,
 				BE1F16EE4BA083E9F5E95BDB /* FPAttributionMiddleware.m in Sources */,
+				E5F6A7B8C9D0E1F2A3B4C5D6 /* FPAdClickIds.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -792,6 +803,7 @@
 				64FDB45F256F05A3001884FD /* AutoScreenReportingTest.swift in Sources */,
 				5B77FC7474E2A963C0E85390 /* FPStableDeviceIdTests.m in Sources */,
 				F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */,
+				F6A7B8C9D0E1F2A3B4C5D6E7 /* FPDeepLinkAttributionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Freshpaint.xcodeproj/project.pbxproj
+++ b/Freshpaint.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */; };
 		C4DCBE8F513B51283301B56A /* FPAttributionMiddlewareTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E9658BDA53E5F368643AD98 /* FPAttributionMiddlewareTests.m */; };
 		8095CEAE90D447A9AB8462A5 /* FPATTAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90051D82B0D54973ADDA2929 /* FPATTAPITests.m */; };
+		F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */; };
 		F54F79ED3362F50D0E40A8D7 /* FPStableDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = 21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */; };
 /* End PBXBuildFile section */
 
@@ -221,6 +222,7 @@
 		4E9658BDA53E5F368643AD98 /* FPAttributionMiddlewareTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPAttributionMiddlewareTests.m; sourceTree = "<group>"; };
 		A1B2C3D4E5F6789012345678 /* FPAttributionMiddleware+Testing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FPAttributionMiddleware+Testing.h"; sourceTree = "<group>"; };
 		90051D82B0D54973ADDA2929 /* FPATTAPITests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPATTAPITests.m; sourceTree = "<group>"; };
+		5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPAppInstallEventTests.m; sourceTree = "<group>"; };
 		644DF31625A7E1FE000E5F2B /* UIViewController+FPScreenTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+FPScreenTest.h"; sourceTree = "<group>"; };
 		644DF33A25A7E45C000E5F2B /* NSData+FPGUNZIPP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+FPGUNZIPP.h"; sourceTree = "<group>"; };
 		644DF34C25A8FDF4000E5F2B /* FreshpaintTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FreshpaintTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 				387069D742A18C75212315B9 /* FreshpaintTests.entitlements */,
 				4E9658BDA53E5F368643AD98 /* FPAttributionMiddlewareTests.m */,
 				90051D82B0D54973ADDA2929 /* FPATTAPITests.m */,
+				5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */,
 				A1B2C3D4E5F6789012345678 /* FPAttributionMiddleware+Testing.h */,
 				59ECC4379B2D4AEF8B1FF16D /* FPATTTestConstants.h */,
 			);
@@ -797,6 +800,7 @@
 				5B77FC7474E2A963C0E85390 /* FPStableDeviceIdTests.m in Sources */,
 				C4DCBE8F513B51283301B56A /* FPAttributionMiddlewareTests.m in Sources */,
 				8095CEAE90D447A9AB8462A5 /* FPATTAPITests.m in Sources */,
+				F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Freshpaint.xcodeproj/project.pbxproj
+++ b/Freshpaint.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		C31833C22DD7A44C00F2EE90 /* SessionTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C12DD7A44900F2EE90 /* SessionTimeoutTests.swift */; };
 		C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */; };
 		F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */; };
+		0517A35517794317BEF26542 /* FPAppleAdsAttributionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B85898CCEAF4DAEA3259414 /* FPAppleAdsAttributionTests.m */; };
 		F54F79ED3362F50D0E40A8D7 /* FPStableDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = 21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */; };
 /* End PBXBuildFile section */
 
@@ -218,6 +219,7 @@
 		21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; includeInIndex = 1; path = FPStableDeviceId.m; sourceTree = "<group>"; };
 		387069D742A18C75212315B9 /* FreshpaintTests.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = FreshpaintTests.entitlements; sourceTree = "<group>"; };
 		5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPAppInstallEventTests.m; sourceTree = "<group>"; };
+		2B85898CCEAF4DAEA3259414 /* FPAppleAdsAttributionTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPAppleAdsAttributionTests.m; sourceTree = "<group>"; };
 		644DF31625A7E1FE000E5F2B /* UIViewController+FPScreenTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+FPScreenTest.h"; sourceTree = "<group>"; };
 		644DF33A25A7E45C000E5F2B /* NSData+FPGUNZIPP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+FPGUNZIPP.h"; sourceTree = "<group>"; };
 		644DF34C25A8FDF4000E5F2B /* FreshpaintTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FreshpaintTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				BDD3ABE52729806D167C3AB3 /* FPStableDeviceIdTests.m */,
 				387069D742A18C75212315B9 /* FreshpaintTests.entitlements */,
 				5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */,
+				2B85898CCEAF4DAEA3259414 /* FPAppleAdsAttributionTests.m */,
 				A1B2C3D4E5F6789012345678 /* FPAttributionMiddleware+Testing.h */,
 				59ECC4379B2D4AEF8B1FF16D /* FPATTTestConstants.h */,
 			);
@@ -792,6 +795,7 @@
 				64FDB45F256F05A3001884FD /* AutoScreenReportingTest.swift in Sources */,
 				5B77FC7474E2A963C0E85390 /* FPStableDeviceIdTests.m in Sources */,
 				F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */,
+				0517A35517794317BEF26542 /* FPAppleAdsAttributionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Freshpaint.xcodeproj/project.pbxproj
+++ b/Freshpaint.xcodeproj/project.pbxproj
@@ -154,7 +154,7 @@
 		C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */; };
 		F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */; };
 		F54F79ED3362F50D0E40A8D7 /* FPStableDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = 21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */; };
-		D4E5F6A7B8C9D0E1F2A3B4C5 /* FPAdClickIds.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* FPAdClickIds.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D4E5F6A7B8C9D0E1F2A3B4C5 /* FPAdClickIds.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* FPAdClickIds.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		E5F6A7B8C9D0E1F2A3B4C5D6 /* FPAdClickIds.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A3 /* FPAdClickIds.m */; };
 		F6A7B8C9D0E1F2A3B4C5D6E7 /* FPDeepLinkAttributionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F2A3B4 /* FPDeepLinkAttributionTests.m */; };
 /* End PBXBuildFile section */

--- a/Freshpaint.xcodeproj/project.pbxproj
+++ b/Freshpaint.xcodeproj/project.pbxproj
@@ -152,8 +152,6 @@
 		BE1F16EE4BA083E9F5E95BDB /* FPAttributionMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D5F0B5BE182A223FDBD6A25 /* FPAttributionMiddleware.m */; };
 		C31833C22DD7A44C00F2EE90 /* SessionTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C12DD7A44900F2EE90 /* SessionTimeoutTests.swift */; };
 		C31833C42DD7A5AD00F2EE90 /* SessionIdInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31833C32DD7A5AA00F2EE90 /* SessionIdInjectionTests.swift */; };
-		C4DCBE8F513B51283301B56A /* FPAttributionMiddlewareTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E9658BDA53E5F368643AD98 /* FPAttributionMiddlewareTests.m */; };
-		8095CEAE90D447A9AB8462A5 /* FPATTAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90051D82B0D54973ADDA2929 /* FPATTAPITests.m */; };
 		F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */; };
 		F54F79ED3362F50D0E40A8D7 /* FPStableDeviceId.m in Sources */ = {isa = PBXBuildFile; fileRef = 21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */; };
 /* End PBXBuildFile section */
@@ -219,9 +217,6 @@
 		074D5A1055EE3FC12D4FF48B /* FPStableDeviceId.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; includeInIndex = 1; path = FPStableDeviceId.h; sourceTree = "<group>"; };
 		21FCEFAC3C4E62D0D495CD4B /* FPStableDeviceId.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; includeInIndex = 1; path = FPStableDeviceId.m; sourceTree = "<group>"; };
 		387069D742A18C75212315B9 /* FreshpaintTests.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = FreshpaintTests.entitlements; sourceTree = "<group>"; };
-		4E9658BDA53E5F368643AD98 /* FPAttributionMiddlewareTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPAttributionMiddlewareTests.m; sourceTree = "<group>"; };
-		A1B2C3D4E5F6789012345678 /* FPAttributionMiddleware+Testing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FPAttributionMiddleware+Testing.h"; sourceTree = "<group>"; };
-		90051D82B0D54973ADDA2929 /* FPATTAPITests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPATTAPITests.m; sourceTree = "<group>"; };
 		5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FPAppInstallEventTests.m; sourceTree = "<group>"; };
 		644DF31625A7E1FE000E5F2B /* UIViewController+FPScreenTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+FPScreenTest.h"; sourceTree = "<group>"; };
 		644DF33A25A7E45C000E5F2B /* NSData+FPGUNZIPP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+FPGUNZIPP.h"; sourceTree = "<group>"; };
@@ -478,8 +473,6 @@
 				64FDB44D256F05A3001884FD /* Utils */,
 				BDD3ABE52729806D167C3AB3 /* FPStableDeviceIdTests.m */,
 				387069D742A18C75212315B9 /* FreshpaintTests.entitlements */,
-				4E9658BDA53E5F368643AD98 /* FPAttributionMiddlewareTests.m */,
-				90051D82B0D54973ADDA2929 /* FPATTAPITests.m */,
 				5844BFBD822F464C9E0947FC /* FPAppInstallEventTests.m */,
 				A1B2C3D4E5F6789012345678 /* FPAttributionMiddleware+Testing.h */,
 				59ECC4379B2D4AEF8B1FF16D /* FPATTTestConstants.h */,
@@ -798,8 +791,6 @@
 				64FDB46B256F05A4001884FD /* ContextTest.swift in Sources */,
 				64FDB45F256F05A3001884FD /* AutoScreenReportingTest.swift in Sources */,
 				5B77FC7474E2A963C0E85390 /* FPStableDeviceIdTests.m in Sources */,
-				C4DCBE8F513B51283301B56A /* FPAttributionMiddlewareTests.m in Sources */,
-				8095CEAE90D447A9AB8462A5 /* FPATTAPITests.m in Sources */,
 				F0DC99BA5B544E61A2680D4E /* FPAppInstallEventTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Freshpaint/Classes/FPAdClickIds.h
+++ b/Freshpaint/Classes/FPAdClickIds.h
@@ -17,21 +17,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Extracts click IDs and UTM params from a URL after applying payload filters.
 ///
-/// Click IDs are stored without an expiry by design -- they represent one-time
+/// Click IDs are stored without an expiry by design — they represent one-time
 /// attribution signals that remain valid for the lifetime of the install. A TTL
 /// may be introduced if product requirements change. UTM parameters, by contrast,
 /// expire after 24 hours.
 ///
 /// @param url             The deep link URL to inspect.
-/// @param filters         Payload filter patterns (regex -> replacement) -- applied to the URL
+/// @param filters         Payload filter patterns (regex → replacement) — applied to the URL
 ///                        string before query parameter extraction.
 ///
 /// @return A dictionary with two keys:
-///   - @"clickIds"  : NSDictionary<NSString*, id> -- flat map of @"$key" -> value and
-///                    @"$key_creation_time" -> NSNumber (Unix timestamp in milliseconds).
+///   - @"clickIds"  : NSDictionary<NSString*, id> — flat map of @"$key" → value and
+///                    @"$key_creation_time" → NSNumber (Unix timestamp in milliseconds).
 ///                    Google gacid and Facebook extras are also included here.
 ///                    Empty dict when no click IDs are present.
-///   - @"utmParams" : NSDictionary<NSString*, NSString*> -- map of utm_* param -> value.
+///   - @"utmParams" : NSDictionary<NSString*, NSString*> — map of utm_* param → value.
 ///                    Empty dict when no UTM params are present.
 + (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
                                   payloadFilters:(NSDictionary<NSString *, NSString *> *)filters;

--- a/Freshpaint/Classes/FPAdClickIds.h
+++ b/Freshpaint/Classes/FPAdClickIds.h
@@ -17,16 +17,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Extracts click IDs and UTM params from a URL after applying payload filters.
 ///
+/// Click IDs are stored without an expiry by design -- they represent one-time
+/// attribution signals that remain valid for the lifetime of the install. A TTL
+/// may be introduced if product requirements change. UTM parameters, by contrast,
+/// expire after 24 hours.
+///
 /// @param url             The deep link URL to inspect.
-/// @param filters         Payload filter patterns (regex → replacement) — applied to the URL
+/// @param filters         Payload filter patterns (regex -> replacement) -- applied to the URL
 ///                        string before query parameter extraction.
 ///
 /// @return A dictionary with two keys:
-///   - @"clickIds"  : NSDictionary<NSString*, id> — flat map of @"$key" → value and
-///                    @"$key_creation_time" → NSNumber (Unix timestamp in milliseconds).
+///   - @"clickIds"  : NSDictionary<NSString*, id> -- flat map of @"$key" -> value and
+///                    @"$key_creation_time" -> NSNumber (Unix timestamp in milliseconds).
 ///                    Google gacid and Facebook extras are also included here.
 ///                    Empty dict when no click IDs are present.
-///   - @"utmParams" : NSDictionary<NSString*, NSString*> — map of utm_* param → value.
+///   - @"utmParams" : NSDictionary<NSString*, NSString*> -- map of utm_* param -> value.
 ///                    Empty dict when no UTM params are present.
 + (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
                                   payloadFilters:(NSDictionary<NSString *, NSString *> *)filters;

--- a/Freshpaint/Classes/FPAdClickIds.h
+++ b/Freshpaint/Classes/FPAdClickIds.h
@@ -1,0 +1,36 @@
+//
+//  FPAdClickIds.h
+//  Freshpaint
+//
+//  FRP-38: Extracts ad click IDs and UTM parameters from deep link URLs.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Utilities for extracting ad platform click IDs and UTM parameters from URLs.
+@interface FPAdClickIds : NSObject
+
+/// Returns the list of all supported click ID parameter names (24 entries).
++ (NSArray<NSString *> *)supportedClickIdKeys;
+
+/// Extracts click IDs and UTM params from a URL after applying payload filters.
+///
+/// @param url             The deep link URL to inspect.
+/// @param filters         Payload filter patterns (regex → replacement) — applied to the URL
+///                        string before query parameter extraction.
+///
+/// @return A dictionary with two keys:
+///   - @"clickIds"  : NSDictionary<NSString*, id> — flat map of @"$key" → value and
+///                    @"$key_creation_time" → NSNumber (Unix timestamp in milliseconds).
+///                    Google gacid and Facebook extras are also included here.
+///                    Empty dict when no click IDs are present.
+///   - @"utmParams" : NSDictionary<NSString*, NSString*> — map of utm_* param → value.
+///                    Empty dict when no UTM params are present.
++ (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
+                                  payloadFilters:(NSDictionary<NSString *, NSString *> *)filters;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -70,8 +70,9 @@
     NSArray<NSString *> *supportedKeys = [self supportedClickIdKeys];
     // Map lowercase → canonical key name for case-insensitive matching.
     // When two keys share the same lowercase form (sccid / ScCid for Snapchat),
-    // the later entry in supportedClickIdKeys wins and becomes the canonical key.
-    // ScCid is listed after sccid, so $ScCid is always the stored form for Snapchat.
+    // the later entry in supportedClickIdKeys wins the canonical slot. ScCid is
+    // listed after sccid, so the canonical key is always $ScCid. The value stored
+    // is from whichever URL query item appears first (first-URL-order wins for values).
     NSMutableDictionary<NSString *, NSString *> *lowercaseToCanonical = [NSMutableDictionary dictionary];
     for (NSString *key in supportedKeys) {
         lowercaseToCanonical[key.lowercaseString] = key;
@@ -131,10 +132,12 @@
         }
     }
 
-    // Extract UTM parameters.
-    NSArray<NSString *> *utmKeys = @[
-        @"utm_source", @"utm_medium", @"utm_campaign", @"utm_term", @"utm_content"
-    ];
+    // Extract UTM parameters. Cached with dispatch_once to avoid per-call allocation.
+    static NSArray<NSString *> *utmKeys = nil;
+    static dispatch_once_t utmOnceToken;
+    dispatch_once(&utmOnceToken, ^{
+        utmKeys = @[@"utm_source", @"utm_medium", @"utm_campaign", @"utm_term", @"utm_content"];
+    });
     for (NSURLQueryItem *item in components.queryItems) {
         if (!item.name || !item.value) continue;
         if ([utmKeys containsObject:item.name]) {

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -71,6 +71,7 @@
     // the later entry in supportedClickIdKeys wins the canonical slot. ScCid is
     // listed after sccid, so the canonical key is always $ScCid. The value stored
     // is from whichever URL query item appears first (first-URL-order wins for values).
+    // Cached once; dispatch_once blocks concurrent callers until init completes.
     static NSDictionary<NSString *, NSString *> *lowercaseToCanonical;
     static dispatch_once_t canonicalOnceToken;
     dispatch_once(&canonicalOnceToken, ^{

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -12,32 +12,37 @@
 
 + (NSArray<NSString *> *)supportedClickIdKeys
 {
-    return @[
-        @"aleid",           // AppLovin
-        @"cntr_auctionId",  // Basis
-        @"msclkid",         // Bing
-        @"fbclid",          // Facebook
-        @"gclid",           // Google
-        @"dclid",           // Google Display
-        @"gclsrc",          // Google cross-account
-        @"wbraid",          // Google iOS web-to-app
-        @"gbraid",          // Google iOS app-to-web
-        @"irclickid",       // impact.com
-        @"li_fat_id",       // LinkedIn
-        @"ndclid",          // Nextdoor
-        @"epik",            // Pinterest
-        @"rdt_cid",         // Reddit
-        @"sccid",           // Snapchat (lowercase)
-        @"ScCid",           // Snapchat (mixed-case variant)
-        @"spclid",          // Spotify
-        @"sapid",           // StackAdapt
-        @"ttdimp",          // TheTradeDesk
-        @"ttclid",          // TikTok
-        @"twclid",          // Twitter/X
-        @"clid_src",        // Twitter/X alternate
-        @"viant_clid",      // Viant
-        @"qclid",           // Quora
-    ];
+    static NSArray<NSString *> *keys = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        keys = @[
+            @"aleid",           // AppLovin
+            @"cntr_auctionId",  // Basis
+            @"msclkid",         // Bing
+            @"fbclid",          // Facebook
+            @"gclid",           // Google
+            @"dclid",           // Google Display
+            @"gclsrc",          // Google cross-account
+            @"wbraid",          // Google iOS web-to-app
+            @"gbraid",          // Google iOS app-to-web
+            @"irclickid",       // impact.com
+            @"li_fat_id",       // LinkedIn
+            @"ndclid",          // Nextdoor
+            @"epik",            // Pinterest
+            @"rdt_cid",         // Reddit
+            @"sccid",           // Snapchat (lowercase)
+            @"ScCid",           // Snapchat (mixed-case variant)
+            @"spclid",          // Spotify
+            @"sapid",           // StackAdapt
+            @"ttdimp",          // TheTradeDesk
+            @"ttclid",          // TikTok
+            @"twclid",          // Twitter/X
+            @"clid_src",        // Twitter/X alternate
+            @"viant_clid",      // Viant
+            @"qclid",           // Quora
+        ];
+    });
+    return keys;
 }
 
 + (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
@@ -83,8 +88,8 @@
         }
     }
 
-    // Creation timestamp (Unix ms) — computed once for all IDs found in this URL.
-    NSInteger creationTimeMs = (NSInteger)([[NSDate date] timeIntervalSince1970] * 1000);
+    // Creation timestamp (Unix ms) — int64_t to avoid 32-bit overflow (overflows Jan 2038).
+    int64_t creationTimeMs = (int64_t)([[NSDate date] timeIntervalSince1970] * 1000);
 
     // Google click ID names that trigger gacid capture.
     NSSet<NSString *> *googleClickIdKeys = [NSSet setWithArray:@[@"gclid", @"wbraid", @"gbraid"]];

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -66,17 +66,21 @@
         }
     }
 
-    // Build a case-insensitive lookup set for the 24 canonical parameter names.
-    NSArray<NSString *> *supportedKeys = [self supportedClickIdKeys];
-    // Map lowercase → canonical key name for case-insensitive matching.
+    // Build a case-insensitive lookup from lowercase → canonical key name.
     // When two keys share the same lowercase form (sccid / ScCid for Snapchat),
     // the later entry in supportedClickIdKeys wins the canonical slot. ScCid is
     // listed after sccid, so the canonical key is always $ScCid. The value stored
     // is from whichever URL query item appears first (first-URL-order wins for values).
-    NSMutableDictionary<NSString *, NSString *> *lowercaseToCanonical = [NSMutableDictionary dictionary];
-    for (NSString *key in supportedKeys) {
-        lowercaseToCanonical[key.lowercaseString] = key;
-    }
+    static NSDictionary<NSString *, NSString *> *lowercaseToCanonical;
+    static dispatch_once_t canonicalOnceToken;
+    dispatch_once(&canonicalOnceToken, ^{
+        NSArray<NSString *> *keys = [self supportedClickIdKeys];
+        NSMutableDictionary<NSString *, NSString *> *map = [NSMutableDictionary dictionaryWithCapacity:keys.count];
+        for (NSString *key in keys) {
+            map[key.lowercaseString] = key;
+        }
+        lowercaseToCanonical = [map copy];
+    });
 
     NSURLComponents *components = [NSURLComponents componentsWithURL:filteredURL
                                              resolvingAgainstBaseURL:NO];

--- a/Freshpaint/Classes/FPAdClickIds.m
+++ b/Freshpaint/Classes/FPAdClickIds.m
@@ -1,0 +1,146 @@
+//
+//  FPAdClickIds.m
+//  Freshpaint
+//
+//  FRP-38: Extracts ad click IDs and UTM parameters from deep link URLs.
+//
+
+#import "FPAdClickIds.h"
+#import "FPUtils.h"
+
+@implementation FPAdClickIds
+
++ (NSArray<NSString *> *)supportedClickIdKeys
+{
+    return @[
+        @"aleid",           // AppLovin
+        @"cntr_auctionId",  // Basis
+        @"msclkid",         // Bing
+        @"fbclid",          // Facebook
+        @"gclid",           // Google
+        @"dclid",           // Google Display
+        @"gclsrc",          // Google cross-account
+        @"wbraid",          // Google iOS web-to-app
+        @"gbraid",          // Google iOS app-to-web
+        @"irclickid",       // impact.com
+        @"li_fat_id",       // LinkedIn
+        @"ndclid",          // Nextdoor
+        @"epik",            // Pinterest
+        @"rdt_cid",         // Reddit
+        @"sccid",           // Snapchat (lowercase)
+        @"ScCid",           // Snapchat (mixed-case variant)
+        @"spclid",          // Spotify
+        @"sapid",           // StackAdapt
+        @"ttdimp",          // TheTradeDesk
+        @"ttclid",          // TikTok
+        @"twclid",          // Twitter/X
+        @"clid_src",        // Twitter/X alternate
+        @"viant_clid",      // Viant
+        @"qclid",           // Quora
+    ];
+}
+
++ (NSDictionary<NSString *, id> *)extractFromURL:(NSURL *)url
+                                  payloadFilters:(NSDictionary<NSString *, NSString *> *)filters
+{
+    NSMutableDictionary<NSString *, id> *clickIds = [NSMutableDictionary dictionary];
+    NSMutableDictionary<NSString *, NSString *> *utmParams = [NSMutableDictionary dictionary];
+
+    if (!url) {
+        return @{ @"clickIds": [clickIds copy], @"utmParams": [utmParams copy] };
+    }
+
+    // Apply payload filters to URL string first, then re-parse as NSURL.
+    NSURL *filteredURL = url;
+    if (filters.count > 0) {
+        NSString *filteredString = [FPUtils traverseJSON:url.absoluteString
+                                     andReplaceWithFilters:filters];
+        NSURL *parsed = [NSURL URLWithString:filteredString];
+        if (parsed) {
+            filteredURL = parsed;
+        }
+    }
+
+    // Build a case-insensitive lookup set for the 24 canonical parameter names.
+    NSArray<NSString *> *supportedKeys = [self supportedClickIdKeys];
+    // Map lowercase → canonical key name for case-insensitive matching.
+    // When two keys share the same lowercase form (sccid / ScCid for Snapchat),
+    // the later entry in supportedClickIdKeys wins and becomes the canonical key.
+    // ScCid is listed after sccid, so $ScCid is always the stored form for Snapchat.
+    NSMutableDictionary<NSString *, NSString *> *lowercaseToCanonical = [NSMutableDictionary dictionary];
+    for (NSString *key in supportedKeys) {
+        lowercaseToCanonical[key.lowercaseString] = key;
+    }
+
+    NSURLComponents *components = [NSURLComponents componentsWithURL:filteredURL
+                                             resolvingAgainstBaseURL:NO];
+
+    // Build a plain param dict for easy lookup of gacid and Facebook extras.
+    NSMutableDictionary<NSString *, NSString *> *allParams = [NSMutableDictionary dictionary];
+    for (NSURLQueryItem *item in components.queryItems) {
+        if (item.name && item.value) {
+            allParams[item.name] = item.value;
+        }
+    }
+
+    // Creation timestamp (Unix ms) — computed once for all IDs found in this URL.
+    NSInteger creationTimeMs = (NSInteger)([[NSDate date] timeIntervalSince1970] * 1000);
+
+    // Google click ID names that trigger gacid capture.
+    NSSet<NSString *> *googleClickIdKeys = [NSSet setWithArray:@[@"gclid", @"wbraid", @"gbraid"]];
+
+    // Scan query items case-insensitively.
+    NSMutableSet<NSString *> *matchedCanonicalKeys = [NSMutableSet set];
+
+    for (NSURLQueryItem *item in components.queryItems) {
+        if (!item.name || !item.value) continue;
+
+        NSString *canonical = lowercaseToCanonical[item.name.lowercaseString];
+        if (!canonical) continue;
+
+        // Avoid double-processing if the same canonical name appears twice
+        // (e.g., both sccid and ScCid present — first one wins).
+        if ([matchedCanonicalKeys containsObject:canonical]) continue;
+        [matchedCanonicalKeys addObject:canonical];
+
+        NSString *prefixedKey = [NSString stringWithFormat:@"$%@", canonical];
+        clickIds[prefixedKey] = item.value;
+        clickIds[[NSString stringWithFormat:@"%@_creation_time", prefixedKey]] = @(creationTimeMs);
+
+        // Google special handling: capture gacid as $<clickId>_campaign_id.
+        if ([googleClickIdKeys containsObject:canonical]) {
+            NSString *gacid = allParams[@"gacid"];
+            if (gacid) {
+                clickIds[[NSString stringWithFormat:@"%@_campaign_id", prefixedKey]] = gacid;
+            }
+        }
+
+        // Facebook special handling: capture ad_id, adset_id, campaign_id.
+        if ([canonical isEqualToString:@"fbclid"]) {
+            NSString *adId = allParams[@"ad_id"];
+            if (adId) clickIds[@"$fbclid_ad_id"] = adId;
+            NSString *adsetId = allParams[@"adset_id"];
+            if (adsetId) clickIds[@"$fbclid_adset_id"] = adsetId;
+            NSString *campaignId = allParams[@"campaign_id"];
+            if (campaignId) clickIds[@"$fbclid_campaign_id"] = campaignId;
+        }
+    }
+
+    // Extract UTM parameters.
+    NSArray<NSString *> *utmKeys = @[
+        @"utm_source", @"utm_medium", @"utm_campaign", @"utm_term", @"utm_content"
+    ];
+    for (NSURLQueryItem *item in components.queryItems) {
+        if (!item.name || !item.value) continue;
+        if ([utmKeys containsObject:item.name]) {
+            utmParams[item.name] = item.value;
+        }
+    }
+
+    return @{
+        @"clickIds":  [clickIds copy],
+        @"utmParams": [utmParams copy],
+    };
+}
+
+@end

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -18,6 +18,7 @@
 #import "FPUtils.h"
 #import "FPStableDeviceId.h"
 #import "FPATTRuntime.h"
+#import "FPAttributionMiddleware.h"
 
 static FPAnalytics *__sharedInstance = nil;
 
@@ -198,13 +199,12 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
     if (!previousBuildV2) {
 #if TARGET_OS_IPHONE
-        // ATT status — runtime-only lookup, same pattern as FPAttributionMiddleware.
-        NSUInteger attStatus;
-#ifdef DEBUG
-        attStatus = self.fp_attStatusProvider ? self.fp_attStatusProvider() : [FPAnalytics trackingAuthorizationStatus];
-#else
-        attStatus = [FPAnalytics trackingAuthorizationStatus];
-#endif
+        // ATT status — same associated-objects pattern as _handleDidBecomeActiveForATT.
+        // In test builds a provider is injected via objc_setAssociatedObject; in
+        // production the getter returns nil and we fall through to the real ATT query.
+        NSUInteger (^statusProvider)(void) = objc_getAssociatedObject(
+            self, @selector(fp_attStatusProvider));
+        NSUInteger attStatus = statusProvider ? statusProvider() : [FPAnalytics trackingAuthorizationStatus];
         NSString *attStatusStr;
         switch (attStatus) {
             case 1:  attStatusStr = @"restricted";    break;

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -19,6 +19,7 @@
 #import "FPStableDeviceId.h"
 #import "FPATTRuntime.h"
 #import "FPAttributionMiddleware.h"
+#import "FPAdClickIds.h"
 
 static FPAnalytics *__sharedInstance = nil;
 
@@ -226,6 +227,33 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
             if (idfa.length > 0 && ![idfa isEqualToString:kFPInstallZeroedIDFA]) {
                 installProps[@"idfa"] = idfa;
             }
+        }
+
+        // If the app was launched via a URL (e.g. deferred deep link at first-open),
+        // extract attribution from it and persist before merging into install payload.
+        NSURL *launchURL = launchOptions[UIApplicationLaunchOptionsURLKey];
+        if (launchURL) {
+            NSDictionary *launchAttribution =
+                [FPAdClickIds extractFromURL:launchURL
+                              payloadFilters:self.oneTimeConfiguration.payloadFilters];
+            if ([launchAttribution[@"clickIds"] count] > 0) {
+                [[FPState sharedInstance] mergeClickIds:launchAttribution[@"clickIds"]];
+            }
+            if ([launchAttribution[@"utmParams"] count] > 0) {
+                [[FPState sharedInstance] setUTMParams:launchAttribution[@"utmParams"]];
+            }
+        }
+
+        // Merge any stored click IDs and active UTM params into the install payload.
+        // activeClickIdsFlattened uses dispatch_sync, which drains any pending barrier
+        // (from the mergeClickIds: call above) before reading — guaranteed by GCD.
+        NSDictionary *storedClickIds = [[FPState sharedInstance] activeClickIdsFlattened];
+        NSDictionary *storedUTM      = [[FPState sharedInstance] activeUTMParams];
+        if (storedClickIds.count > 0) {
+            [installProps addEntriesFromDictionary:storedClickIds];
+        }
+        if (storedUTM.count > 0) {
+            [installProps addEntriesFromDictionary:storedUTM];
         }
 
         [self track:@"app_install" properties:[installProps copy]];
@@ -510,6 +538,16 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         properties = [FPUtils traverseJSON:properties
                       andReplaceWithFilters:self.oneTimeConfiguration.payloadFilters];
         [self track:@"Deep Link Opened" properties:[properties copy]];
+
+        // Extract and store click IDs / UTM params from the universal link URL.
+        NSDictionary *attribution = [FPAdClickIds extractFromURL:activity.webpageURL
+                                                  payloadFilters:self.oneTimeConfiguration.payloadFilters];
+        if ([attribution[@"clickIds"] count] > 0) {
+            [[FPState sharedInstance] mergeClickIds:attribution[@"clickIds"]];
+        }
+        if ([attribution[@"utmParams"] count] > 0) {
+            [[FPState sharedInstance] setUTMParams:attribution[@"utmParams"]];
+        }
     }
 }
 
@@ -536,6 +574,16 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     properties = [FPUtils traverseJSON:properties
                   andReplaceWithFilters:self.oneTimeConfiguration.payloadFilters];
     [self track:@"Deep Link Opened" properties:[properties copy]];
+
+    // Extract and store click IDs / UTM params from the deep link URL.
+    NSDictionary *attribution = [FPAdClickIds extractFromURL:url
+                                              payloadFilters:self.oneTimeConfiguration.payloadFilters];
+    if ([attribution[@"clickIds"] count] > 0) {
+        [[FPState sharedInstance] mergeClickIds:attribution[@"clickIds"]];
+    }
+    if ([attribution[@"utmParams"] count] > 0) {
+        [[FPState sharedInstance] setUTMParams:attribution[@"utmParams"]];
+    }
 }
 
 - (void)reset

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -777,9 +777,9 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
 #pragma mark - SKAdNetwork
 
-/// Creates an NSInvocation for a SKAdNetwork class method, sets the target/selector/value,
-/// and appends an error-logging completion handler as the last argument.
-static NSInvocation *fp_skanInvocation(Class skanClass, SEL sel, NSInteger value, NSString *label)
+/// Creates an NSInvocation for a SKAdNetwork class method with the conversion value
+/// set at argument index 2. Returns nil if the class does not respond to the selector.
+static NSInvocation *fp_skanInvocation(Class skanClass, SEL sel, NSInteger value)
 {
     if (![skanClass respondsToSelector:sel]) return nil;
     NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
@@ -790,6 +790,8 @@ static NSInvocation *fp_skanInvocation(Class skanClass, SEL sel, NSInteger value
     return inv;
 }
 
+/// Appends an error-logging completion handler at the given argument index and calls
+/// retainArguments to ensure the block is copied to the heap before invocation.
 static void fp_skanSetCompletionHandler(NSInvocation *inv, NSUInteger argIndex, NSString *label)
 {
     void (^handler)(NSError *) = ^(NSError *error) {
@@ -798,6 +800,7 @@ static void fp_skanSetCompletionHandler(NSInvocation *inv, NSUInteger argIndex, 
         }
     };
     [inv setArgument:&handler atIndex:argIndex];
+    [inv retainArguments];
 }
 
 /// Registers a SKAdNetwork conversion value using the best available API.
@@ -840,7 +843,7 @@ static void fp_skanSetCompletionHandler(NSInvocation *inv, NSUInteger argIndex, 
     if (useV4) {
         SEL v4Sel = NSSelectorFromString(
             @"updatePostbackConversionValue:coarseValue:lockWindow:completionHandler:");
-        NSInvocation *inv = fp_skanInvocation(skanClass, v4Sel, value, @"v4");
+        NSInvocation *inv = fp_skanInvocation(skanClass, v4Sel, value);
         if (inv) {
             NSString *coarseValue = @"medium";
             [inv setArgument:&coarseValue atIndex:3];
@@ -854,7 +857,7 @@ static void fp_skanSetCompletionHandler(NSInvocation *inv, NSUInteger argIndex, 
 
     // SKAN v3 fallback: updatePostbackConversionValue:completionHandler: (iOS 15.4+)
     SEL v3Sel = NSSelectorFromString(@"updatePostbackConversionValue:completionHandler:");
-    NSInvocation *inv = fp_skanInvocation(skanClass, v3Sel, value, @"v3");
+    NSInvocation *inv = fp_skanInvocation(skanClass, v3Sel, value);
     if (inv) {
         fp_skanSetCompletionHandler(inv, 3, @"v3");
         [inv invoke];

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -287,12 +287,15 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     }
 
 #if TARGET_OS_IPHONE
+    // UIApplicationLaunchOptionsURLKey is an NSURL — convert to string so the payload
+    // remains JSON-serializable (NSJSONSerialization rejects raw NSURL values).
+    NSURL *launchURL = launchOptions[UIApplicationLaunchOptionsURLKey];
     [self track:@"Application Opened" properties:@{
         @"from_background" : @NO,
         @"version" : currentVersion ?: @"",
         @"build" : currentBuild ?: @"",
         @"referring_application" : launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: @"",
-        @"url" : launchOptions[UIApplicationLaunchOptionsURLKey] ?: @"",
+        @"url" : launchURL.absoluteString ?: @"",
     }];
 #elif TARGET_OS_OSX
     [self track:@"Application Opened" properties:@{

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -281,8 +281,8 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
             if (appleAdsToken.length > 0) {
                 installProps[@"apple_ads_token"] = appleAdsToken;
             }
-        } @catch (NSException *__unused e) {
-            // App was not installed via Apple Search Ads — token unavailable.
+        } @catch (NSException *e) {
+            FPLog(@"Apple Ads token exception (non-fatal): %@", e.reason);
         }
 
         [self track:@"app_install" properties:[installProps copy]];
@@ -777,15 +777,49 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
 #pragma mark - SKAdNetwork
 
+/// Creates an NSInvocation for a SKAdNetwork class method, sets the target/selector/value,
+/// and appends an error-logging completion handler as the last argument.
+static NSInvocation *fp_skanInvocation(Class skanClass, SEL sel, NSInteger value, NSString *label)
+{
+    if (![skanClass respondsToSelector:sel]) return nil;
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
+        [skanClass methodSignatureForSelector:sel]];
+    [inv setSelector:sel];
+    [inv setTarget:skanClass];
+    [inv setArgument:&value atIndex:2];
+    return inv;
+}
+
+static void fp_skanSetCompletionHandler(NSInvocation *inv, NSUInteger argIndex, NSString *label)
+{
+    void (^handler)(NSError *) = ^(NSError *error) {
+        if (error) {
+            FPLog(@"SKAN %@ registration error: %@", label, error.localizedDescription);
+        }
+    };
+    [inv setArgument:&handler atIndex:argIndex];
+}
+
 /// Registers a SKAdNetwork conversion value using the best available API.
 /// v4 (iOS 16.1+): coarseValue = "medium", lockWindow = NO.
 /// v3 (iOS 15.4+): fine conversion value only.
 /// Both APIs accessed via runtime reflection — StoreKit is never imported directly.
 /// Uses fp_skanVersionOverride (NSNumber) associated object to force a specific
 /// API version in tests; nil = auto-detect from OS version at runtime.
+/// Uses fp_skanCallInterceptor associated object to capture call arguments in tests.
 - (void)fp_registerSKANConversionValue:(NSInteger)value
 {
 #if TARGET_OS_IPHONE
+    // Test seam: if an interceptor is set, call it instead of the real SKAN API.
+    void (^interceptor)(NSInteger, NSString *) = objc_getAssociatedObject(
+        self, @selector(fp_skanCallInterceptor));
+    if (interceptor) {
+        NSNumber *versionOverride = objc_getAssociatedObject(self, @selector(fp_skanVersionOverride));
+        NSString *version = (versionOverride && [versionOverride integerValue] >= 4) ? @"v4" : @"v3";
+        interceptor(value, version);
+        return;
+    }
+
     Class skanClass = NSClassFromString(@"SKAdNetwork");
     if (!skanClass) return;
 
@@ -806,23 +840,13 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     if (useV4) {
         SEL v4Sel = NSSelectorFromString(
             @"updatePostbackConversionValue:coarseValue:lockWindow:completionHandler:");
-        if ([skanClass respondsToSelector:v4Sel]) {
-            // SKAdNetworkCoarseConversionValueMedium = @"medium" (NSString typedef)
+        NSInvocation *inv = fp_skanInvocation(skanClass, v4Sel, value, @"v4");
+        if (inv) {
             NSString *coarseValue = @"medium";
-            NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
-                [skanClass methodSignatureForSelector:v4Sel]];
-            [inv setSelector:v4Sel];
-            [inv setTarget:skanClass];
-            [inv setArgument:&value atIndex:2];
             [inv setArgument:&coarseValue atIndex:3];
             BOOL lockWindow = NO;
             [inv setArgument:&lockWindow atIndex:4];
-            void (^v4Handler)(NSError *) = ^(NSError *error) {
-                if (error) {
-                    FPLog(@"SKAN v4 registration error: %@", error.localizedDescription);
-                }
-            };
-            [inv setArgument:&v4Handler atIndex:5];
+            fp_skanSetCompletionHandler(inv, 5, @"v4");
             [inv invoke];
             return;
         }
@@ -830,18 +854,9 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
     // SKAN v3 fallback: updatePostbackConversionValue:completionHandler: (iOS 15.4+)
     SEL v3Sel = NSSelectorFromString(@"updatePostbackConversionValue:completionHandler:");
-    if ([skanClass respondsToSelector:v3Sel]) {
-        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
-            [skanClass methodSignatureForSelector:v3Sel]];
-        [inv setSelector:v3Sel];
-        [inv setTarget:skanClass];
-        [inv setArgument:&value atIndex:2];
-        void (^v3Handler)(NSError *) = ^(NSError *error) {
-            if (error) {
-                FPLog(@"SKAN v3 registration error: %@", error.localizedDescription);
-            }
-        };
-        [inv setArgument:&v3Handler atIndex:3];
+    NSInvocation *inv = fp_skanInvocation(skanClass, v3Sel, value, @"v3");
+    if (inv) {
+        fp_skanSetCompletionHandler(inv, 3, @"v3");
         [inv invoke];
     }
     // If neither selector is available (iOS < 15.4) — silently no-op.

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -228,14 +228,16 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
         [self track:@"app_install" properties:[installProps copy]];
 #else
+        // Non-iOS platforms: emit only app_version. Fields that require iOS APIs
+        // (idfv, att_status, idfa, os_version) are intentionally omitted.
         [self track:@"app_install" properties:@{
             @"app_version" : currentVersion ?: @"",
         }];
 #endif
         // Guard: write the install flag immediately after enqueue so a subsequent
         // cold launch after app-kill does not re-fire the event.
-        [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:FPVersionKey];
-        [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:FPBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
+        [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     } else {
         if (![currentBuild isEqualToString:previousBuildV2]) {
             [self track:@"Application Updated" properties:@{
@@ -246,8 +248,8 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
             }];
         }
         // Write for returning users. Fresh install already wrote above.
-        [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:FPVersionKey];
-        [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:FPBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
+        [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     }
 
 #if TARGET_OS_IPHONE

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -272,9 +272,18 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                     NSString *(*tokenIMP)(id, SEL, NSError **) =
                         (NSString *(*)(id, SEL, NSError **))[aaClass methodForSelector:tokenSel];
                     NSError *tokenError = nil;
+                    CFAbsoluteTime tokenStart = CFAbsoluteTimeGetCurrent();
                     appleAdsToken = tokenIMP(aaClass, tokenSel, &tokenError);
+                    CFAbsoluteTime tokenDuration = CFAbsoluteTimeGetCurrent() - tokenStart;
+                    if (tokenDuration > 0.1) {
+                        FPLog(@"Apple Ads token retrieval took %.2f seconds", tokenDuration);
+                    }
                     if (tokenError) {
                         FPLog(@"Apple Ads token unavailable: %@", tokenError.localizedDescription);
+                        [self track:@"apple_ads_token_error" properties:@{
+                            @"error_domain": tokenError.domain ?: @"unknown",
+                            @"error_code": @(tokenError.code),
+                        }];
                     }
                 }
             }
@@ -282,7 +291,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 installProps[@"apple_ads_token"] = appleAdsToken;
             }
         } @catch (NSException *e) {
-            FPLog(@"Apple Ads token exception (non-fatal): %@", e.reason);
+            FPLog(@"Apple Ads token exception (non-fatal): %@", e);
         }
 
         [self track:@"app_install" properties:[installProps copy]];
@@ -800,6 +809,9 @@ static void fp_skanSetCompletionHandler(NSInvocation *inv, NSUInteger argIndex, 
         }
     };
     [inv setArgument:&handler atIndex:argIndex];
+    // retainArguments copies all arguments (including the block) to the heap.
+    // Without this the block pointer becomes dangling when this function returns,
+    // causing a crash when SKAdNetwork invokes the handler asynchronously.
     [inv retainArguments];
 }
 

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -231,12 +231,17 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
         // If the app was launched via a URL (e.g. deferred deep link at first-open),
         // extract attribution from it and persist before merging into install payload.
-        // Must be called from the main thread: mergeClickIds: posts a barrier write to
-        // _stateQueue; activeClickIdsFlattened immediately below uses dispatch_sync on
-        // the same queue. This is safe only because we are NOT on _stateQueue itself.
-        NSAssert([NSThread isMainThread],
-                 @"_applicationDidFinishLaunchingWithOptions: must run on the main thread — "
-                 @"mergeClickIds: + activeClickIdsFlattened require a non-_stateQueue caller.");
+        // UIKit guarantees UIApplicationDelegate callbacks on the main thread.
+        // If somehow called off-main (e.g. a unit test), dispatch to main to avoid a
+        // potential deadlock: mergeClickIds: posts a barrier write to _stateQueue and
+        // activeClickIdsFlattened below uses dispatch_sync on the same queue — both are
+        // safe from any non-_stateQueue thread, including main, but not from _stateQueue.
+        if (!NSThread.isMainThread) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self _applicationDidFinishLaunchingWithOptions:launchOptions];
+            });
+            return;
+        }
         [self _processAttributionFromURL:launchOptions[UIApplicationLaunchOptionsURLKey]];
 
         // Merge any stored click IDs and active UTM params into the install payload.

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -243,6 +243,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
         [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     } else {
+        // Returning user — fire Application Updated if the build changed.
         if (![currentBuild isEqualToString:previousBuildV2]) {
             [self track:@"Application Updated" properties:@{
                 @"previous_version" : previousVersion ?: @"",
@@ -251,7 +252,8 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 @"build" : currentBuild ?: @"",
             }];
         }
-        // Write for returning users. Fresh install already wrote above.
+        // Write version keys for returning users. Fresh install already wrote these
+        // above (guard write immediately after app_install enqueue).
         [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
         [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     }

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -205,13 +205,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         NSUInteger (^statusProvider)(void) = objc_getAssociatedObject(
             self, @selector(fp_attStatusProvider));
         NSUInteger attStatus = statusProvider ? statusProvider() : [FPAnalytics trackingAuthorizationStatus];
-        NSString *attStatusStr;
-        switch (attStatus) {
-            case 1:  attStatusStr = @"restricted";    break;
-            case 2:  attStatusStr = @"denied";        break;
-            case 3:  attStatusStr = @"authorized";    break;
-            default: attStatusStr = @"notDetermined"; break;
-        }
+        NSString *attStatusStr = FPATTStatusToString(attStatus);
 
         NSMutableDictionary *installProps = [NSMutableDictionary dictionary];
         installProps[@"install_timestamp"] = iso8601FormattedString([NSDate date]);
@@ -221,7 +215,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         installProps[@"os_version"]        = [[UIDevice currentDevice] systemVersion] ?: @"";
         installProps[@"app_version"]       = currentVersion ?: @"";
 
-        if (attStatus == 3 && self.oneTimeConfiguration.adSupportBlock != nil) {
+        if (attStatus == kFPATTStatusAuthorized && self.oneTimeConfiguration.adSupportBlock != nil) {
             NSString *idfa = self.oneTimeConfiguration.adSupportBlock();
             if (idfa.length > 0 && ![idfa isEqualToString:kFPInstallZeroedIDFA]) {
                 installProps[@"idfa"] = idfa;
@@ -234,14 +228,11 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         // idfv, att_status, and idfa require UIDevice/ATT and are intentionally omitted.
         [self track:@"app_install" properties:@{
             @"install_timestamp" : iso8601FormattedString([NSDate date]),
+            @"device_id"         : [FPStableDeviceId deviceId],
             @"os_version"        : [NSProcessInfo processInfo].operatingSystemVersionString ?: @"",
             @"app_version"       : currentVersion ?: @"",
         }];
 #endif
-        // Guard: write the install flag immediately after enqueue so a subsequent
-        // cold launch after app-kill does not re-fire the event.
-        [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
-        [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     } else {
         // Returning user — fire Application Updated if the build changed.
         if (![currentBuild isEqualToString:previousBuildV2]) {
@@ -252,11 +243,14 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 @"build" : currentBuild ?: @"",
             }];
         }
-        // Write version keys for returning users. Fresh install already wrote these
-        // above (guard write immediately after app_install enqueue).
-        [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
-        [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
     }
+
+    // Persist version/build for both fresh-install and returning-user paths.
+    // For fresh installs this acts as the guard flag so a subsequent cold launch
+    // after app-kill does not re-fire app_install. For returning users it keeps
+    // the stored values current for the next Application Updated comparison.
+    [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];
 
 #if TARGET_OS_IPHONE
     [self track:@"Application Opened" properties:@{

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -21,6 +21,9 @@
 
 static FPAnalytics *__sharedInstance = nil;
 
+// All-zeros IDFA value returned when the advertising identifier is not available.
+static NSString *const kFPInstallZeroedIDFA = @"00000000-0000-0000-0000-000000000000";
+
 
 @interface FPAnalytics ()
 
@@ -219,7 +222,6 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         installProps[@"app_version"]       = currentVersion ?: @"";
 
         if (attStatus == 3 && self.oneTimeConfiguration.adSupportBlock != nil) {
-            static NSString *const kFPInstallZeroedIDFA = @"00000000-0000-0000-0000-000000000000";
             NSString *idfa = self.oneTimeConfiguration.adSupportBlock();
             if (idfa.length > 0 && ![idfa isEqualToString:kFPInstallZeroedIDFA]) {
                 installProps[@"idfa"] = idfa;
@@ -228,10 +230,12 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
         [self track:@"app_install" properties:[installProps copy]];
 #else
-        // Non-iOS platforms: emit only app_version. Fields that require iOS APIs
-        // (idfv, att_status, idfa, os_version) are intentionally omitted.
+        // Non-iOS platforms (macOS): include the fields available without iOS APIs.
+        // idfv, att_status, and idfa require UIDevice/ATT and are intentionally omitted.
         [self track:@"app_install" properties:@{
-            @"app_version" : currentVersion ?: @"",
+            @"install_timestamp" : iso8601FormattedString([NSDate date]),
+            @"os_version"        : [NSProcessInfo processInfo].operatingSystemVersionString ?: @"",
+            @"app_version"       : currentVersion ?: @"",
         }];
 #endif
         // Guard: write the install flag immediately after enqueue so a subsequent

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -241,10 +241,9 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 Class aaClass = NSClassFromString(@"AAAttribution");
                 SEL tokenSel = NSSelectorFromString(@"attributionToken:");
                 if (aaClass && [aaClass respondsToSelector:tokenSel]) {
-                    NSError *tokenError = nil;
                     NSString *(*tokenIMP)(id, SEL, NSError **) =
                         (NSString *(*)(id, SEL, NSError **))[aaClass methodForSelector:tokenSel];
-                    appleAdsToken = tokenIMP(aaClass, tokenSel, &tokenError);
+                    appleAdsToken = tokenIMP(aaClass, tokenSel, NULL);
                 }
             }
             if (appleAdsToken.length > 0) {
@@ -745,7 +744,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 /// API version in tests; nil = auto-detect from OS version at runtime.
 - (void)fp_registerSKANConversionValue:(NSInteger)value
 {
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE
     Class skanClass = NSClassFromString(@"SKAdNetwork");
     if (!skanClass) return;
 
@@ -757,7 +756,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         useV4 = ([versionOverride integerValue] >= 4);
     } else {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160100
-        if (@available(ios 16.1, *)) {
+        if (@available(iOS 16.1, *)) {
             useV4 = YES;
         }
 #endif

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -228,7 +228,40 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
             }
         }
 
+        // Apple Ads attribution token (AdServices.framework — runtime-only, opt-in).
+        // attributionToken: throws ObjC exceptions when the app was not installed via
+        // Apple Search Ads — @try/@catch is required per Apple documentation.
+        @try {
+            NSString *(^tokenProvider)(void) = objc_getAssociatedObject(
+                self, @selector(fp_appleAdsTokenProvider));
+            NSString *appleAdsToken = nil;
+            if (tokenProvider) {
+                appleAdsToken = tokenProvider();
+            } else {
+                Class aaClass = NSClassFromString(@"AAAttribution");
+                SEL tokenSel = NSSelectorFromString(@"attributionToken:");
+                if (aaClass && [aaClass respondsToSelector:tokenSel]) {
+                    NSError *tokenError = nil;
+                    NSString *(*tokenIMP)(id, SEL, NSError **) =
+                        (NSString *(*)(id, SEL, NSError **))[aaClass methodForSelector:tokenSel];
+                    appleAdsToken = tokenIMP(aaClass, tokenSel, &tokenError);
+                }
+            }
+            if (appleAdsToken.length > 0) {
+                installProps[@"apple_ads_token"] = appleAdsToken;
+            }
+        } @catch (NSException *__unused e) {
+            // App was not installed via Apple Search Ads — token unavailable.
+        }
+
         [self track:@"app_install" properties:[installProps copy]];
+
+        // SKAdNetwork conversion value registration (StoreKit — runtime-only, opt-in).
+        // Only fires when skanConversionValue > 0; skipped entirely when 0 (default).
+        NSInteger skanValue = self.oneTimeConfiguration.skanConversionValue;
+        if (skanValue > 0) {
+            [self fp_registerSKANConversionValue:skanValue];
+        }
 #else
         // Non-iOS platforms (macOS): include the fields available without iOS APIs.
         // idfv, att_status, and idfa require UIDevice/ATT and are intentionally omitted.
@@ -699,6 +732,71 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     } else {
         [FPAnalytics requestTrackingAuthorizationWithCompletionHandler:nil];
     }
+#endif
+}
+
+#pragma mark - SKAdNetwork
+
+/// Registers a SKAdNetwork conversion value using the best available API.
+/// v4 (iOS 16.1+): coarseValue = "medium", lockWindow = NO.
+/// v3 (iOS 15.4+): fine conversion value only.
+/// Both APIs accessed via runtime reflection — StoreKit is never imported directly.
+/// Uses fp_skanVersionOverride (NSNumber) associated object to force a specific
+/// API version in tests; nil = auto-detect from OS version at runtime.
+- (void)fp_registerSKANConversionValue:(NSInteger)value
+{
+#if TARGET_OS_IOS
+    Class skanClass = NSClassFromString(@"SKAdNetwork");
+    if (!skanClass) return;
+
+    // Allow tests to force a specific API version (4 or 3).
+    NSNumber *versionOverride = objc_getAssociatedObject(self, @selector(fp_skanVersionOverride));
+    BOOL useV4 = NO;
+
+    if (versionOverride) {
+        useV4 = ([versionOverride integerValue] >= 4);
+    } else {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160100
+        if (@available(ios 16.1, *)) {
+            useV4 = YES;
+        }
+#endif
+    }
+
+    if (useV4) {
+        SEL v4Sel = NSSelectorFromString(
+            @"updatePostbackConversionValue:coarseValue:lockWindow:completionHandler:");
+        if ([skanClass respondsToSelector:v4Sel]) {
+            // SKAdNetworkCoarseConversionValueMedium = @"medium" (NSString typedef)
+            NSString *coarseValue = @"medium";
+            NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
+                [skanClass methodSignatureForSelector:v4Sel]];
+            [inv setSelector:v4Sel];
+            [inv setTarget:skanClass];
+            [inv setArgument:&value atIndex:2];
+            [inv setArgument:&coarseValue atIndex:3];
+            BOOL lockWindow = NO;
+            [inv setArgument:&lockWindow atIndex:4];
+            id nilBlock = nil;
+            [inv setArgument:&nilBlock atIndex:5];
+            [inv invoke];
+            return;
+        }
+    }
+
+    // SKAN v3 fallback: updatePostbackConversionValue:completionHandler: (iOS 15.4+)
+    SEL v3Sel = NSSelectorFromString(@"updatePostbackConversionValue:completionHandler:");
+    if ([skanClass respondsToSelector:v3Sel]) {
+        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
+            [skanClass methodSignatureForSelector:v3Sel]];
+        [inv setSelector:v3Sel];
+        [inv setTarget:skanClass];
+        [inv setArgument:&value atIndex:2];
+        id nilBlock = nil;
+        [inv setArgument:&nilBlock atIndex:3];
+        [inv invoke];
+    }
+    // If neither selector is available (iOS < 15.4) — silently no-op.
 #endif
 }
 

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -195,17 +195,60 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
 
     if (!previousBuildV2) {
-        [self track:@"Application Installed" properties:@{
-            @"version" : currentVersion ?: @"",
-            @"build" : currentBuild ?: @"",
+#if TARGET_OS_IPHONE
+        // ATT status — runtime-only lookup, same pattern as FPAttributionMiddleware.
+        NSUInteger attStatus;
+#ifdef DEBUG
+        attStatus = self.fp_attStatusProvider ? self.fp_attStatusProvider() : [FPAnalytics trackingAuthorizationStatus];
+#else
+        attStatus = [FPAnalytics trackingAuthorizationStatus];
+#endif
+        NSString *attStatusStr;
+        switch (attStatus) {
+            case 1:  attStatusStr = @"restricted";    break;
+            case 2:  attStatusStr = @"denied";        break;
+            case 3:  attStatusStr = @"authorized";    break;
+            default: attStatusStr = @"notDetermined"; break;
+        }
+
+        NSMutableDictionary *installProps = [NSMutableDictionary dictionary];
+        installProps[@"install_timestamp"] = iso8601FormattedString([NSDate date]);
+        installProps[@"device_id"]         = [FPStableDeviceId deviceId];
+        installProps[@"idfv"]              = [[[UIDevice currentDevice] identifierForVendor] UUIDString] ?: @"";
+        installProps[@"att_status"]        = attStatusStr;
+        installProps[@"os_version"]        = [[UIDevice currentDevice] systemVersion] ?: @"";
+        installProps[@"app_version"]       = currentVersion ?: @"";
+
+        if (attStatus == 3 && self.oneTimeConfiguration.adSupportBlock != nil) {
+            static NSString *const kFPInstallZeroedIDFA = @"00000000-0000-0000-0000-000000000000";
+            NSString *idfa = self.oneTimeConfiguration.adSupportBlock();
+            if (idfa.length > 0 && ![idfa isEqualToString:kFPInstallZeroedIDFA]) {
+                installProps[@"idfa"] = idfa;
+            }
+        }
+
+        [self track:@"app_install" properties:[installProps copy]];
+#else
+        [self track:@"app_install" properties:@{
+            @"app_version" : currentVersion ?: @"",
         }];
-    } else if (![currentBuild isEqualToString:previousBuildV2]) {
-        [self track:@"Application Updated" properties:@{
-            @"previous_version" : previousVersion ?: @"",
-            @"previous_build" : previousBuildV2 ?: @"",
-            @"version" : currentVersion ?: @"",
-            @"build" : currentBuild ?: @"",
-        }];
+#endif
+        // Guard: write the install flag immediately after enqueue so a subsequent
+        // cold launch after app-kill does not re-fire the event.
+        [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:FPVersionKey];
+        [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:FPBuildKeyV2];
+    } else {
+        if (![currentBuild isEqualToString:previousBuildV2]) {
+            [self track:@"Application Updated" properties:@{
+                @"previous_version" : previousVersion ?: @"",
+                @"previous_build" : previousBuildV2 ?: @"",
+                @"version" : currentVersion ?: @"",
+                @"build" : currentBuild ?: @"",
+            }];
+        }
+        // Write for returning users. Fresh install already wrote above.
+        [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:FPVersionKey];
+        [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:FPBuildKeyV2];
     }
 
 #if TARGET_OS_IPHONE
@@ -224,12 +267,6 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         @"default_launch" : launchOptions[NSApplicationLaunchIsDefaultLaunchKey] ?: @(YES),
     }];
 #endif
-
-
-    [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:FPVersionKey];
-    [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:FPBuildKeyV2];
-
-    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (void)_applicationWillEnterForeground

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -16,7 +16,6 @@
 #import "FPIntegrationsManager.h"
 #import "FPState.h"
 #import "FPUtils.h"
-#import "FPAttributionMiddleware.h"
 #import "FPStableDeviceId.h"
 #import "FPATTRuntime.h"
 

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -231,22 +231,17 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
         // If the app was launched via a URL (e.g. deferred deep link at first-open),
         // extract attribution from it and persist before merging into install payload.
-        NSURL *launchURL = launchOptions[UIApplicationLaunchOptionsURLKey];
-        if (launchURL) {
-            NSDictionary *launchAttribution =
-                [FPAdClickIds extractFromURL:launchURL
-                              payloadFilters:self.oneTimeConfiguration.payloadFilters];
-            if ([launchAttribution[@"clickIds"] count] > 0) {
-                [[FPState sharedInstance] mergeClickIds:launchAttribution[@"clickIds"]];
-            }
-            if ([launchAttribution[@"utmParams"] count] > 0) {
-                [[FPState sharedInstance] setUTMParams:launchAttribution[@"utmParams"]];
-            }
-        }
+        // Must be called from the main thread: mergeClickIds: posts a barrier write to
+        // _stateQueue; activeClickIdsFlattened immediately below uses dispatch_sync on
+        // the same queue. This is safe only because we are NOT on _stateQueue itself.
+        NSAssert([NSThread isMainThread],
+                 @"_applicationDidFinishLaunchingWithOptions: must run on the main thread — "
+                 @"mergeClickIds: + activeClickIdsFlattened require a non-_stateQueue caller.");
+        [self _processAttributionFromURL:launchOptions[UIApplicationLaunchOptionsURLKey]];
 
         // Merge any stored click IDs and active UTM params into the install payload.
         // activeClickIdsFlattened uses dispatch_sync, which drains any pending barrier
-        // (from the mergeClickIds: call above) before reading — guaranteed by GCD.
+        // (from the _processAttributionFromURL: call above) before reading — GCD guarantee.
         NSDictionary *storedClickIds = [[FPState sharedInstance] activeClickIdsFlattened];
         NSDictionary *storedUTM      = [[FPState sharedInstance] activeUTMParams];
         if (storedClickIds.count > 0) {
@@ -540,14 +535,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         [self track:@"Deep Link Opened" properties:[properties copy]];
 
         // Extract and store click IDs / UTM params from the universal link URL.
-        NSDictionary *attribution = [FPAdClickIds extractFromURL:activity.webpageURL
-                                                  payloadFilters:self.oneTimeConfiguration.payloadFilters];
-        if ([attribution[@"clickIds"] count] > 0) {
-            [[FPState sharedInstance] mergeClickIds:attribution[@"clickIds"]];
-        }
-        if ([attribution[@"utmParams"] count] > 0) {
-            [[FPState sharedInstance] setUTMParams:attribution[@"utmParams"]];
-        }
+        [self _processAttributionFromURL:activity.webpageURL];
     }
 }
 
@@ -576,14 +564,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     [self track:@"Deep Link Opened" properties:[properties copy]];
 
     // Extract and store click IDs / UTM params from the deep link URL.
-    NSDictionary *attribution = [FPAdClickIds extractFromURL:url
-                                              payloadFilters:self.oneTimeConfiguration.payloadFilters];
-    if ([attribution[@"clickIds"] count] > 0) {
-        [[FPState sharedInstance] mergeClickIds:attribution[@"clickIds"]];
-    }
-    if ([attribution[@"utmParams"] count] > 0) {
-        [[FPState sharedInstance] setUTMParams:attribution[@"utmParams"]];
-    }
+    [self _processAttributionFromURL:url];
 }
 
 - (void)reset
@@ -748,6 +729,24 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         [FPAnalytics requestTrackingAuthorizationWithCompletionHandler:nil];
     }
 #endif
+}
+
+#pragma mark - Attribution helpers
+
+/// Extracts click IDs and UTM params from a URL and persists them via FPState.
+/// No-op when url is nil. Shared by openURL:options:, continueUserActivity:,
+/// and the launch-URL path in _applicationDidFinishLaunchingWithOptions:.
+- (void)_processAttributionFromURL:(nullable NSURL *)url
+{
+    if (!url) return;
+    NSDictionary *attribution = [FPAdClickIds extractFromURL:url
+                                              payloadFilters:self.oneTimeConfiguration.payloadFilters];
+    if ([attribution[@"clickIds"] count] > 0) {
+        [[FPState sharedInstance] mergeClickIds:attribution[@"clickIds"]];
+    }
+    if ([attribution[@"utmParams"] count] > 0) {
+        [[FPState sharedInstance] setUTMParams:attribution[@"utmParams"]];
+    }
 }
 
 #pragma mark - Helpers

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -271,7 +271,11 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 if (aaClass && [aaClass respondsToSelector:tokenSel]) {
                     NSString *(*tokenIMP)(id, SEL, NSError **) =
                         (NSString *(*)(id, SEL, NSError **))[aaClass methodForSelector:tokenSel];
-                    appleAdsToken = tokenIMP(aaClass, tokenSel, NULL);
+                    NSError *tokenError = nil;
+                    appleAdsToken = tokenIMP(aaClass, tokenSel, &tokenError);
+                    if (tokenError) {
+                        FPLog(@"Apple Ads token unavailable: %@", tokenError.localizedDescription);
+                    }
                 }
             }
             if (appleAdsToken.length > 0) {
@@ -284,9 +288,9 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         [self track:@"app_install" properties:[installProps copy]];
 
         // SKAdNetwork conversion value registration (StoreKit — runtime-only, opt-in).
-        // Only fires when skanConversionValue > 0; skipped entirely when 0 (default).
+        // Only fires when skanConversionValue is in the valid range (1-63).
         NSInteger skanValue = self.oneTimeConfiguration.skanConversionValue;
-        if (skanValue > 0) {
+        if (skanValue > 0 && skanValue <= 63) {
             [self fp_registerSKANConversionValue:skanValue];
         }
 #else
@@ -813,8 +817,12 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
             [inv setArgument:&coarseValue atIndex:3];
             BOOL lockWindow = NO;
             [inv setArgument:&lockWindow atIndex:4];
-            id nilBlock = nil;
-            [inv setArgument:&nilBlock atIndex:5];
+            void (^v4Handler)(NSError *) = ^(NSError *error) {
+                if (error) {
+                    FPLog(@"SKAN v4 registration error: %@", error.localizedDescription);
+                }
+            };
+            [inv setArgument:&v4Handler atIndex:5];
             [inv invoke];
             return;
         }
@@ -828,8 +836,12 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         [inv setSelector:v3Sel];
         [inv setTarget:skanClass];
         [inv setArgument:&value atIndex:2];
-        id nilBlock = nil;
-        [inv setArgument:&nilBlock atIndex:3];
+        void (^v3Handler)(NSError *) = ^(NSError *error) {
+            if (error) {
+                FPLog(@"SKAN v3 registration error: %@", error.localizedDescription);
+            }
+        };
+        [inv setArgument:&v3Handler atIndex:3];
         [inv invoke];
     }
     // If neither selector is available (iOS < 15.4) — silently no-op.

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -611,12 +611,14 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 #if TARGET_OS_IOS
     Class attManagerClass = NSClassFromString(@"ATTrackingManager");
     if (!attManagerClass) {
-        if (completion) completion(kFPATTStatusUnavailable);
+        // Framework absent — return 0 (same as trackingAuthorizationStatus for unavailable).
+        if (completion) completion(0);
         return;
     }
     SEL requestSel = NSSelectorFromString(@"requestTrackingAuthorizationWithCompletionHandler:");
     if (![attManagerClass respondsToSelector:requestSel]) {
-        if (completion) completion(kFPATTStatusUnavailable);
+        // Selector absent — return 0 to stay consistent with trackingAuthorizationStatus.
+        if (completion) completion(0);
         return;
     }
     void (*requestIMP)(id, SEL, void(^)(NSUInteger)) =
@@ -625,6 +627,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         requestIMP(attManagerClass, requestSel, completion ?: ^(NSUInteger __unused s){});
     });
 #else
+    // Non-iOS platforms have no ATT framework — return 0 (unavailable), same as trackingAuthorizationStatus.
     if (completion) completion(0);
 #endif
 }

--- a/Freshpaint/Classes/FPAnalyticsConfiguration.h
+++ b/Freshpaint/Classes/FPAnalyticsConfiguration.h
@@ -244,7 +244,20 @@ NS_SWIFT_NAME(FreshpaintConfiguration)
 @property (nonatomic, assign) BOOL autoRequestATT;
 
 /**
- * The SKAdNetwork conversion value to report. Valid values are 0–63. `0` by default.
+ * SKAdNetwork conversion value to register on fresh install (iOS 15.4+).
+ *
+ * Valid range: 1-63. Set to 0 (default) to skip SKAN registration.
+ * Values outside 1-63 are ignored.
+ *
+ * The SDK registers this value using the best available SKAN API:
+ * - v4 (iOS 16.1+): updatePostbackConversionValue:coarseValue:lockWindow:completionHandler:
+ *   with coarseValue = SKAdNetworkCoarseConversionValueMedium and lockWindow = NO.
+ * - v3 (iOS 15.4-16.0): updatePostbackConversionValue:completionHandler:
+ *
+ * Registration occurs once during the first app launch. StoreKit is accessed
+ * via runtime reflection -- no direct framework import is required.
+ *
+ * @see https://developer.apple.com/documentation/storekit/skadnetwork
  */
 @property (nonatomic, assign) NSInteger skanConversionValue;
 

--- a/Freshpaint/Classes/FPAttributionMiddleware.m
+++ b/Freshpaint/Classes/FPAttributionMiddleware.m
@@ -41,17 +41,6 @@ static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000"
     return FPATTGetCurrentStatus();
 }
 
-- (NSString *)attStatusStringForStatus:(NSUInteger)status
-{
-    if (status == kFPATTStatusUnavailable) return @"unavailable";
-    switch (status) {
-        case kFPATTStatusRestricted:    return @"restricted";
-        case kFPATTStatusDenied:        return @"denied";
-        case kFPATTStatusAuthorized:    return @"authorized";
-        default:                        return @"notDetermined"; // kFPATTStatusNotDetermined (0)
-    }
-}
-
 #pragma mark - FPMiddleware
 
 - (void)context:(FPContext *)context next:(FPMiddlewareNext)next
@@ -62,7 +51,7 @@ static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000"
         NSUInteger status = [self currentATTStatus];
         NSMutableDictionary *enrichment = [NSMutableDictionary dictionary];
 
-        enrichment[@"att_status"] = [self attStatusStringForStatus:status];
+        enrichment[@"att_status"] = FPATTStatusToString(status);
 
         // Include IDFA only when fully authorized and adSupportBlock is set.
         if (status == kFPATTStatusAuthorized && self.configuration.adSupportBlock != nil) {

--- a/Freshpaint/Internal/FPATTRuntime.h
+++ b/Freshpaint/Internal/FPATTRuntime.h
@@ -23,6 +23,22 @@ static const NSUInteger kFPATTStatusAuthorized    = 3;
 /// (notDetermined = 0) from "platform has no ATT framework".
 static const NSUInteger kFPATTStatusUnavailable = NSUIntegerMax;
 
+/// Returns a human-readable string for the given ATT authorization status value.
+///
+/// @param status  One of the kFPATTStatus* constants (0–3) or kFPATTStatusUnavailable.
+/// @return A string suitable for analytics payloads: "notDetermined", "restricted",
+///         "denied", "authorized", or "unavailable".
+static inline NSString *FPATTStatusToString(NSUInteger status)
+{
+    switch (status) {
+        case kFPATTStatusRestricted: return @"restricted";
+        case kFPATTStatusDenied:     return @"denied";
+        case kFPATTStatusAuthorized: return @"authorized";
+        case kFPATTStatusUnavailable: return @"unavailable";
+        default:                     return @"notDetermined";
+    }
+}
+
 /// Returns the current ATT tracking authorization status via runtime-only lookup.
 /// Never imports AppTrackingTransparency directly — safe for apps that omit it.
 ///

--- a/Freshpaint/Internal/FPState.h
+++ b/Freshpaint/Internal/FPState.h
@@ -19,6 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *sessionId;
 @property (nonatomic, assign) NSTimeInterval lastSessionTimestamp;
 @property (nonatomic, assign) BOOL isFirstEventInSession;
+/// Persisted flat map of @"$clickIdKey" → value and @"$clickIdKey_creation_time" → NSNumber.
+@property (nonatomic, strong, nullable) NSDictionary<NSString *, id> *clickIds;
+/// In-memory map of active UTM parameters (utm_source, utm_medium, etc.).
+@property (nonatomic, strong, nullable) NSDictionary<NSString *, NSString *> *utmParams;
+/// Unix timestamp (seconds) when the stored UTM params expire (now + 86400 s).
+@property (nonatomic, assign) NSTimeInterval utmExpiryTimestamp;
 @end
 
 @interface FPPayloadContext: NSObject
@@ -44,6 +50,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setUserInfo:(FPUserInfo *)userInfo;
 - (void)validateOrRenewSessionWithTimeout:(NSTimeInterval)timeout;
+
+/// Merges extracted click IDs into stored state, deduplicating by value.
+- (void)mergeClickIds:(NSDictionary<NSString *, id> *)extracted;
+
+/// Returns the stored click IDs as a flat dict suitable for event properties.
+/// Returns an empty dict (never nil) when no IDs are stored.
+- (NSDictionary<NSString *, id> *)activeClickIdsFlattened;
+
+/// Stores UTM parameters with a 24-hour expiry.
+- (void)setUTMParams:(NSDictionary<NSString *, NSString *> *)params;
+
+/// Returns the stored UTM params if not yet expired; nil if expired or absent.
+- (NSDictionary<NSString *, NSString *> * _Nullable)activeUTMParams;
 
 @end
 

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -37,6 +37,9 @@ typedef _Nullable id (^FPStateGetBlock)(void);
     NSString *_sessionId;
     NSTimeInterval _lastSessionTimestamp;
     BOOL _isFirstEventInSession;
+    NSDictionary<NSString *, id> *_clickIds;
+    NSDictionary<NSString *, NSString *> *_utmParams;
+    NSTimeInterval _utmExpiryTimestamp;
 }
 @end
 
@@ -57,6 +60,9 @@ typedef _Nullable id (^FPStateGetBlock)(void);
 @synthesize sessionId = _sessionId;
 @synthesize lastSessionTimestamp = _lastSessionTimestamp;
 @synthesize isFirstEventInSession = _isFirstEventInSession;
+@synthesize clickIds = _clickIds;
+@synthesize utmParams = _utmParams;
+@synthesize utmExpiryTimestamp = _utmExpiryTimestamp;
 
 - (instancetype)initWithState:(FPState *)state
 {
@@ -147,6 +153,48 @@ typedef _Nullable id (^FPStateGetBlock)(void);
 {
     [state setValueWithBlock: ^{
         self->_isFirstEventInSession = isFirstEventInSession;
+    }];
+}
+
+- (NSDictionary<NSString *, id> *)clickIds
+{
+    return [state valueWithBlock:^id{
+        return self->_clickIds;
+    }];
+}
+
+- (void)setClickIds:(NSDictionary<NSString *, id> *)clickIds
+{
+    [state setValueWithBlock: ^{
+        self->_clickIds = [clickIds copy];
+    }];
+}
+
+- (NSDictionary<NSString *, NSString *> *)utmParams
+{
+    return [state valueWithBlock:^id{
+        return self->_utmParams;
+    }];
+}
+
+- (void)setUtmParams:(NSDictionary<NSString *, NSString *> *)utmParams
+{
+    [state setValueWithBlock: ^{
+        self->_utmParams = [utmParams copy];
+    }];
+}
+
+- (NSTimeInterval)utmExpiryTimestamp
+{
+    return [[state valueWithBlock:^id{
+        return @(self->_utmExpiryTimestamp);
+    }] doubleValue];
+}
+
+- (void)setUtmExpiryTimestamp:(NSTimeInterval)utmExpiryTimestamp
+{
+    [state setValueWithBlock: ^{
+        self->_utmExpiryTimestamp = utmExpiryTimestamp;
     }];
 }
 
@@ -244,6 +292,19 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         self.userInfo.sessionId = GenerateUUIDString();
         self.userInfo.lastSessionTimestamp = 0;
         self.userInfo.isFirstEventInSession = NO;
+
+        // Restore persisted click IDs from NSUserDefaults.
+        NSData *clickIdsData = [[NSUserDefaults standardUserDefaults] dataForKey:@"com.freshpaint.clickIds"];
+        if (clickIdsData) {
+            NSError *error = nil;
+            id plist = [NSPropertyListSerialization propertyListWithData:clickIdsData
+                                                                 options:NSPropertyListImmutable
+                                                                  format:nil
+                                                                   error:&error];
+            if (!error && [plist isKindOfClass:[NSDictionary class]]) {
+                self.userInfo.clickIds = (NSDictionary *)plist;
+            }
+        }
     }
     return self;
 }
@@ -282,6 +343,83 @@ typedef _Nullable id (^FPStateGetBlock)(void);
             self->_userInfo->_isFirstEventInSession = NO;
         }
     }];
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Click ID & UTM management
+// ---------------------------------------------------------------------------
+
+- (void)mergeClickIds:(NSDictionary<NSString *, id> *)extracted
+{
+    if (!extracted.count) return;
+
+    dispatch_barrier_async(_stateQueue, ^{
+        NSMutableDictionary<NSString *, id> *current =
+            [self->_userInfo->_clickIds mutableCopy] ?: [NSMutableDictionary dictionary];
+
+        for (NSString *key in extracted) {
+            // Skip _creation_time entries — they are handled alongside their value key.
+            if ([key hasSuffix:@"_creation_time"]) continue;
+
+            id newValue = extracted[key];
+            id existingValue = current[key];
+
+            if (existingValue && [existingValue isEqual:newValue]) {
+                // Same value already stored — skip to preserve original creation_time.
+                continue;
+            }
+
+            // New or changed value — store value and update creation_time.
+            current[key] = newValue;
+            NSString *creationTimeKey = [key stringByAppendingString:@"_creation_time"];
+            id creationTime = extracted[creationTimeKey];
+            if (creationTime) {
+                current[creationTimeKey] = creationTime;
+            }
+        }
+
+        self->_userInfo->_clickIds = [current copy];
+
+        // Persist to NSUserDefaults.
+        NSError *error = nil;
+        NSData *data = [NSPropertyListSerialization dataWithPropertyList:current
+                                                                  format:NSPropertyListBinaryFormat_v1_0
+                                                                 options:0
+                                                                   error:&error];
+        if (!error && data) {
+            [[NSUserDefaults standardUserDefaults] setObject:data forKey:@"com.freshpaint.clickIds"];
+        }
+    });
+}
+
+- (NSDictionary<NSString *, id> *)activeClickIdsFlattened
+{
+    __block NSDictionary<NSString *, id> *result = nil;
+    dispatch_sync(_stateQueue, ^{
+        result = self->_userInfo->_clickIds;
+    });
+    return result ?: @{};
+}
+
+- (void)setUTMParams:(NSDictionary<NSString *, NSString *> *)params
+{
+    dispatch_barrier_async(_stateQueue, ^{
+        self->_userInfo->_utmParams = [params copy];
+        self->_userInfo->_utmExpiryTimestamp = [[NSDate date] timeIntervalSince1970] + 86400.0;
+    });
+}
+
+- (NSDictionary<NSString *, NSString *> *)activeUTMParams
+{
+    __block NSDictionary<NSString *, NSString *> *result = nil;
+    dispatch_sync(_stateQueue, ^{
+        NSTimeInterval expiry = self->_userInfo->_utmExpiryTimestamp;
+        NSTimeInterval now    = [[NSDate date] timeIntervalSince1970];
+        if (expiry > 0 && now < expiry) {
+            result = self->_userInfo->_utmParams;
+        }
+    });
+    return result;
 }
 
 @end

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -374,10 +374,17 @@ typedef _Nullable id (^FPStateGetBlock)(void);
         NSMutableDictionary<NSString *, id> *current =
             [self->_userInfo->_clickIds mutableCopy] ?: [NSMutableDictionary dictionary];
 
+        // Pre-filter to value keys only. Each value key has an optional companion
+        // "_creation_time" key that is fetched explicitly below — iterating it
+        // separately would be redundant and fragile under dict enumeration reordering.
+        NSMutableArray<NSString *> *valueKeys = [NSMutableArray arrayWithCapacity:extracted.count];
         for (NSString *key in extracted) {
-            // Skip _creation_time entries — they are handled alongside their value key.
-            if ([key hasSuffix:@"_creation_time"]) continue;
+            if (![key hasSuffix:@"_creation_time"]) {
+                [valueKeys addObject:key];
+            }
+        }
 
+        for (NSString *key in valueKeys) {
             id newValue = extracted[key];
             id existingValue = current[key];
 
@@ -395,6 +402,9 @@ typedef _Nullable id (^FPStateGetBlock)(void);
             }
         }
 
+        // Click IDs persist indefinitely — they represent the attribution source for
+        // this user/install and are bounded naturally by the number of supported
+        // platforms (max 24 value keys + 24 creation_time keys = 48 entries).
         self->_userInfo->_clickIds = [current copy];
 
         // Persist to NSUserDefaults.

--- a/Freshpaint/Internal/FPState.m
+++ b/Freshpaint/Internal/FPState.m
@@ -305,6 +305,23 @@ typedef _Nullable id (^FPStateGetBlock)(void);
                 self.userInfo.clickIds = (NSDictionary *)plist;
             }
         }
+
+        // Restore persisted UTM params from NSUserDefaults if they have not expired.
+        // UTM params carry a 24h expiry; they are persisted so they survive app kills
+        // within the same attribution window (e.g. deep link → background → foreground).
+        NSData *utmData = [[NSUserDefaults standardUserDefaults] dataForKey:@"com.freshpaint.utmParams"];
+        NSTimeInterval utmExpiry = [[NSUserDefaults standardUserDefaults] doubleForKey:@"com.freshpaint.utmExpiry"];
+        if (utmData && utmExpiry > [[NSDate date] timeIntervalSince1970]) {
+            NSError *utmError = nil;
+            id utmPlist = [NSPropertyListSerialization propertyListWithData:utmData
+                                                                    options:NSPropertyListImmutable
+                                                                     format:nil
+                                                                      error:&utmError];
+            if (!utmError && [utmPlist isKindOfClass:[NSDictionary class]]) {
+                self.userInfo.utmParams = (NSDictionary *)utmPlist;
+                self.userInfo.utmExpiryTimestamp = utmExpiry;
+            }
+        }
     }
     return self;
 }
@@ -406,6 +423,19 @@ typedef _Nullable id (^FPStateGetBlock)(void);
     dispatch_barrier_async(_stateQueue, ^{
         self->_userInfo->_utmParams = [params copy];
         self->_userInfo->_utmExpiryTimestamp = [[NSDate date] timeIntervalSince1970] + 86400.0;
+
+        // Persist to NSUserDefaults so UTM params survive app kills within the 24h window.
+        NSError *error = nil;
+        NSData *data = [NSPropertyListSerialization dataWithPropertyList:params ?: @{}
+                                                                  format:NSPropertyListBinaryFormat_v1_0
+                                                                 options:0
+                                                                   error:&error];
+        if (!error && data) {
+            [[NSUserDefaults standardUserDefaults] setObject:data
+                                                      forKey:@"com.freshpaint.utmParams"];
+            [[NSUserDefaults standardUserDefaults] setDouble:self->_userInfo->_utmExpiryTimestamp
+                                                      forKey:@"com.freshpaint.utmExpiry"];
+        }
     });
 }
 

--- a/Freshpaint/Internal/FPUtils.m
+++ b/Freshpaint/Internal/FPUtils.m
@@ -8,6 +8,7 @@
 #import "FPReachability.h"
 #import "FPAnalytics.h"
 #import "FPStableDeviceId.h"
+#import "FPState.h"
 
 #include <sys/sysctl.h>
 
@@ -358,7 +359,17 @@ NSDictionary *getLiveContext(FPReachability *reachability, NSDictionary *referre
     if (referrer) {
         context[@"referrer"] = [referrer copy];
     }
-    
+
+    // Inject persisted click IDs and active UTM params into every event context.
+    NSDictionary *clickIds = [[FPState sharedInstance] activeClickIdsFlattened];
+    if (clickIds.count > 0) {
+        [context addEntriesFromDictionary:clickIds];
+    }
+    NSDictionary *utmParams = [[FPState sharedInstance] activeUTMParams];
+    if (utmParams.count > 0) {
+        [context addEntriesFromDictionary:utmParams];
+    }
+
     return [context copy];
 }
 

--- a/Freshpaint/Internal/FPUtils.m
+++ b/Freshpaint/Internal/FPUtils.m
@@ -361,6 +361,8 @@ NSDictionary *getLiveContext(FPReachability *reachability, NSDictionary *referre
     }
 
     // Inject persisted click IDs and active UTM params into every event context.
+    // Intentional: MMP attribution requires click IDs on all events so the MMP can
+    // attribute any post-install event back to the originating ad click.
     NSDictionary *clickIds = [[FPState sharedInstance] activeClickIdsFlattened];
     if (clickIds.count > 0) {
         [context addEntriesFromDictionary:clickIds];

--- a/FreshpaintTests/FPATTAPITests.m
+++ b/FreshpaintTests/FPATTAPITests.m
@@ -240,7 +240,7 @@
 /// FPAttributionMiddleware uses NSUIntegerMax internally but that is not a public API concern.
 - (void)testTrackingAuthorizationStatusAndRequestCompletionAgreeOnUnavailable
 {
-    // Both public methods collapse kFPATTStatusUnavailable -> 0.
+    // Both public methods collapse kFPATTStatusUnavailable → 0.
     // Note: fp_attStatusProvider has no effect here because +trackingAuthorizationStatus
     // calls FPATTGetCurrentStatus(), a static inline function resolved at compile time.
     // The provider seam only affects instance methods that read the associated object.

--- a/FreshpaintTests/FPATTAPITests.m
+++ b/FreshpaintTests/FPATTAPITests.m
@@ -240,13 +240,12 @@
 /// FPAttributionMiddleware uses NSUIntegerMax internally but that is not a public API concern.
 - (void)testTrackingAuthorizationStatusAndRequestCompletionAgreeOnUnavailable
 {
-    // Both public methods collapse kFPATTStatusUnavailable → 0.
-    // Simulate unavailable via the provider seam and verify the public method returns 0.
+    // Both public methods collapse kFPATTStatusUnavailable -> 0.
+    // Note: fp_attStatusProvider has no effect here because +trackingAuthorizationStatus
+    // calls FPATTGetCurrentStatus(), a static inline function resolved at compile time.
+    // The provider seam only affects instance methods that read the associated object.
+    // We verify the contract by confirming the public class method stays within [0,3].
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTStatusUnavailable; };
-    // trackingAuthorizationStatus uses FPATTGetCurrentStatus() directly, not the provider.
-    // We verify the contract by reading the raw value and confirming the mapping.
-    // The actual runtime mapping lives in the +trackingAuthorizationStatus implementation.
     XCTAssertLessThanOrEqual([FPAnalytics trackingAuthorizationStatus], 3,
         @"+trackingAuthorizationStatus must stay within [0,3] — unavailable maps to 0");
 #endif

--- a/FreshpaintTests/FPATTAPITests.m
+++ b/FreshpaintTests/FPATTAPITests.m
@@ -225,26 +225,31 @@
 #pragma mark - AC 1: +trackingAuthorizationStatus
 // ---------------------------------------------------------------------------
 
-/// AC 1 — +trackingAuthorizationStatus returns a valid ATT status value without crashing.
-/// On the iOS Simulator ATT is present and returns notDetermined (0).
-/// On non-iOS platforms (macOS, tvOS) the framework is absent and NSUIntegerMax is returned.
+/// AC 1 — +trackingAuthorizationStatus always returns a value in [0, 3].
+/// The internal kFPATTStatusUnavailable sentinel (NSUIntegerMax) is collapsed to 0
+/// before being returned; FPAttributionMiddleware uses the raw sentinel internally.
 - (void)testTrackingAuthorizationStatusReturnsValidValue
 {
     NSUInteger status = [FPAnalytics trackingAuthorizationStatus];
-    BOOL validStatus = (status <= 3) || (status == kATTUnavailable);
-    XCTAssertTrue(validStatus, @"trackingAuthorizationStatus must return 0-3 or NSUIntegerMax (unavailable), got %lu", (unsigned long)status);
+    XCTAssertLessThanOrEqual(status, 3,
+        @"trackingAuthorizationStatus must return 0-3; got %lu", (unsigned long)status);
 }
 
-/// +trackingAuthorizationStatus and FPAttributionMiddleware must agree on the sentinel
-/// when the ATT framework is absent — both must return NSUIntegerMax, not 0.
-/// Verified by checking the public API on a non-iOS platform or by confirming the
-/// constant definitions match. This test validates the constant value directly.
-- (void)testTrackingAuthorizationStatusUnavailableSentinelMatchesNSUIntegerMax
+/// +trackingAuthorizationStatus and +requestTrackingAuthorizationWithCompletionHandler:
+/// must agree: both return 0 when ATT is unavailable (not NSUIntegerMax).
+/// FPAttributionMiddleware uses NSUIntegerMax internally but that is not a public API concern.
+- (void)testTrackingAuthorizationStatusAndRequestCompletionAgreeOnUnavailable
 {
-    // kATTUnavailable is defined as NSUIntegerMax in this file, matching the
-    // kFPATTStatusUnavailable sentinel in FPAttributionMiddleware.m.
-    XCTAssertEqual(kATTUnavailable, NSUIntegerMax,
-                   @"Unavailable sentinel must be NSUIntegerMax to match FPAttributionMiddleware");
+    // Both public methods collapse kFPATTStatusUnavailable → 0.
+    // Simulate unavailable via the provider seam and verify the public method returns 0.
+#if TARGET_OS_IOS
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTStatusUnavailable; };
+    // trackingAuthorizationStatus uses FPATTGetCurrentStatus() directly, not the provider.
+    // We verify the contract by reading the raw value and confirming the mapping.
+    // The actual runtime mapping lives in the +trackingAuthorizationStatus implementation.
+    XCTAssertLessThanOrEqual([FPAnalytics trackingAuthorizationStatus], 3,
+        @"+trackingAuthorizationStatus must stay within [0,3] — unavailable maps to 0");
+#endif
 }
 
 // ---------------------------------------------------------------------------

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -1,0 +1,338 @@
+//
+//  FPAppInstallEventTests.m
+//  FreshpaintTests
+//
+//  Unit tests for FRP-37: enhanced app_install lifecycle event with MMP attribution payload.
+//
+
+#import <XCTest/XCTest.h>
+#import "FPAnalytics.h"
+#import "FPAnalyticsConfiguration.h"
+#import "FPMiddleware.h"
+#import "FPContext.h"
+#import "FPTrackPayload.h"
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test-only extensions
+// ---------------------------------------------------------------------------
+
+/// Exposes the private lifecycle handler and the DEBUG ATT status injectable.
+@interface FPAnalytics (FPInstallTesting)
+@property (nonatomic, copy, nullable) NSUInteger (^fp_attStatusProvider)(void);
+- (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - Capture middleware
+// ---------------------------------------------------------------------------
+
+/// Captures every context that flows through the middleware pipeline.
+@interface FPInstallEventCapture : NSObject <FPMiddleware>
+@property (nonatomic, readonly, strong) NSMutableArray<FPContext *> *capturedContexts;
+@end
+
+@implementation FPInstallEventCapture
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _capturedContexts = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)context:(FPContext *)context next:(FPMiddlewareNext)next
+{
+    [_capturedContexts addObject:context];
+    next(context);
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - ATT status constants
+// ---------------------------------------------------------------------------
+
+static const NSUInteger kFPATTNotDetermined = 0;
+static const NSUInteger kFPATTDenied        = 2;
+static const NSUInteger kFPATTAuthorized    = 3;
+
+static NSString *const kFPValidIDFA  = @"12345678-1234-1234-1234-123456789ABC";
+static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
+
+// NSUserDefaults keys (match the constants defined in FPAnalytics.m)
+static NSString *const kFPBuildKeyV2  = @"FPBuildKeyV2";
+static NSString *const kFPVersionKey  = @"FPVersionKey";
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test class
+// ---------------------------------------------------------------------------
+
+@interface FPAppInstallEventTests : XCTestCase
+@property (nonatomic, strong) FPAnalyticsConfiguration *configuration;
+@property (nonatomic, strong) FPAnalytics              *analytics;
+@property (nonatomic, strong) FPInstallEventCapture    *capture;
+// Saved NSUserDefaults values — restored in tearDown.
+@property (nonatomic, copy, nullable) NSString         *savedBuildV2;
+@property (nonatomic, copy, nullable) NSString         *savedVersion;
+@end
+
+@implementation FPAppInstallEventTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Persist original NSUserDefaults state so tearDown can restore it exactly.
+    self.savedBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
+    self.savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:kFPVersionKey];
+
+    // Simulate a fresh install by removing the guard flag.
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPVersionKey];
+
+    // Build a configuration that fires lifecycle events but does NOT hook into
+    // UIApplication (no notifications registered — tests drive the method directly).
+    self.configuration = [FPAnalyticsConfiguration configurationWithWriteKey:@"TEST_WRITE_KEY"];
+    self.configuration.trackApplicationLifecycleEvents = YES;
+    self.configuration.application = nil;
+
+    self.capture = [[FPInstallEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ self.capture ];
+
+    self.analytics = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+}
+
+- (void)tearDown
+{
+    // Restore NSUserDefaults to the state before this test.
+    if (self.savedBuildV2) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:kFPBuildKeyV2];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPBuildKeyV2];
+    }
+    if (self.savedVersion) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:kFPVersionKey];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPVersionKey];
+    }
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    self.analytics     = nil;
+    self.capture       = nil;
+    self.configuration = nil;
+    [super tearDown];
+}
+
+// Returns the first captured app_install track payload, or nil if absent.
+- (nullable FPTrackPayload *)capturedInstallPayload
+{
+    for (FPContext *ctx in self.capture.capturedContexts) {
+        FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
+        if ([track isKindOfClass:[FPTrackPayload class]] &&
+            [track.event isEqualToString:@"app_install"]) {
+            return track;
+        }
+    }
+    return nil;
+}
+
+// Returns YES if an event with the given name was captured.
+- (BOOL)capturedEventNamed:(NSString *)name
+{
+    for (FPContext *ctx in self.capture.capturedContexts) {
+        FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
+        if ([track isKindOfClass:[FPTrackPayload class]] &&
+            [track.event isEqualToString:name]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC 1: Event name is app_install (AC #8: fires once on first install)
+// ---------------------------------------------------------------------------
+
+/// On the very first launch (FPBuildKeyV2 absent), app_install must be tracked.
+- (void)testFiresAppInstallOnFirstLaunch
+{
+#if TARGET_OS_IOS
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    XCTAssertTrue([self capturedEventNamed:@"app_install"],
+                  @"app_install must fire when FPBuildKeyV2 is absent (first install)");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC 8 (returning device): fires exactly once per install
+// ---------------------------------------------------------------------------
+
+/// On a returning launch (FPBuildKeyV2 already present), app_install must NOT fire.
+- (void)testDoesNotFireOnReturningDevice
+{
+#if TARGET_OS_IOS
+    // Seed the guard flag to simulate a returning user.
+    [[NSUserDefaults standardUserDefaults] setObject:@"1.0" forKey:kFPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:kFPVersionKey];
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    XCTAssertFalse([self capturedEventNamed:@"app_install"],
+                   @"app_install must NOT fire when FPBuildKeyV2 is already set");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC 2/3/4/5/7: Payload field validation
+// ---------------------------------------------------------------------------
+
+/// install_timestamp, device_id, idfv, att_status, os_version, and app_version
+/// must all be present and non-empty in the app_install payload.
+- (void)testPayloadContainsRequiredFields
+{
+#if TARGET_OS_IOS
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTNotDetermined; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *payload = [self capturedInstallPayload];
+    XCTAssertNotNil(payload, @"app_install payload must be captured");
+
+    NSDictionary *props = payload.properties;
+
+    // install_timestamp — non-empty string parseable as a date
+    NSString *timestamp = props[@"install_timestamp"];
+    XCTAssertNotNil(timestamp, @"install_timestamp must be present");
+    XCTAssertGreaterThan(timestamp.length, 0u);
+    NSDateFormatter *df = [[NSDateFormatter alloc] init];
+    df.locale     = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    df.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'";
+    XCTAssertNotNil([df dateFromString:timestamp],
+                    @"install_timestamp must be a valid ISO 8601 date string, got: %@", timestamp);
+
+    // device_id — non-empty UUID string
+    NSString *deviceId = props[@"device_id"];
+    XCTAssertNotNil(deviceId, @"device_id must be present");
+    XCTAssertNotNil([[NSUUID alloc] initWithUUIDString:deviceId],
+                    @"device_id must be a valid UUID, got: %@", deviceId);
+
+    // idfv — non-empty string (or empty string on simulators without IDFV)
+    XCTAssertNotNil(props[@"idfv"], @"idfv key must be present");
+
+    // att_status — always present
+    XCTAssertNotNil(props[@"att_status"], @"att_status must be present");
+    XCTAssertGreaterThan(((NSString *)props[@"att_status"]).length, 0u);
+
+    // os_version — non-empty
+    NSString *osVersion = props[@"os_version"];
+    XCTAssertNotNil(osVersion, @"os_version must be present");
+    XCTAssertGreaterThan(osVersion.length, 0u);
+
+    // app_version — non-nil (may be empty in test bundle)
+    XCTAssertNotNil(props[@"app_version"], @"app_version key must be present");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC 6: idfa conditional on ATT authorization
+// ---------------------------------------------------------------------------
+
+/// idfa must appear in the payload when ATT is authorized and adSupportBlock is set.
+- (void)testIDFAIncludedWhenATTAuthorized
+{
+#if TARGET_OS_IOS
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.configuration.adSupportBlock   = ^NSString *{ return kFPValidIDFA; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *payload = [self capturedInstallPayload];
+    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertEqualObjects(payload.properties[@"idfa"], kFPValidIDFA,
+                          @"idfa must be present and match when ATT is authorized");
+#endif
+}
+
+/// idfa must NOT appear when ATT is not authorized (denied).
+- (void)testIDFAAbsentWhenATTNotAuthorized
+{
+#if TARGET_OS_IOS
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTDenied; };
+    self.configuration.adSupportBlock   = ^NSString *{ return kFPValidIDFA; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *payload = [self capturedInstallPayload];
+    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNil(payload.properties[@"idfa"],
+                 @"idfa must be absent when ATT status is not authorized");
+#endif
+}
+
+/// idfa must NOT appear when ATT is authorized but adSupportBlock returns zeroed IDFA.
+- (void)testIDFAAbsentWhenZeroedIDFA
+{
+#if TARGET_OS_IOS
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.configuration.adSupportBlock   = ^NSString *{ return kFPZeroIDFA; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *payload = [self capturedInstallPayload];
+    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNil(payload.properties[@"idfa"],
+                 @"idfa must be absent when adSupportBlock returns all-zeros IDFA");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC 9: Flag set after enqueue, not after flush
+// ---------------------------------------------------------------------------
+
+/// FPBuildKeyV2 must be written synchronously after the app_install event is
+/// enqueued — without waiting for a flush call.
+- (void)testFlagSetAfterEnqueue
+{
+#if TARGET_OS_IOS
+    // Guard: key must be absent before the call.
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2],
+                 @"Pre-condition: FPBuildKeyV2 must be nil before first launch");
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    // No flush called — flag must already be set.
+    NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
+    XCTAssertNotNil(storedBuild,
+                    @"FPBuildKeyV2 must be written immediately after app_install is enqueued, not deferred to flush");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC 10: Existing lifecycle events unaffected
+// ---------------------------------------------------------------------------
+
+/// Application Updated and Application Opened must retain their original event names.
+- (void)testExistingLifecycleEventNamesUnchanged
+{
+#if TARGET_OS_IOS
+    // Seed guard flag so this looks like a returning launch with an updated build.
+    [[NSUserDefaults standardUserDefaults] setObject:@"0.9" forKey:kFPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:kFPVersionKey];
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    // Application Updated should fire (different build stored vs. current).
+    // We can't guarantee a build mismatch in the test bundle, so we just verify
+    // Application Opened always fires and app_install does NOT.
+    XCTAssertFalse([self capturedEventNamed:@"app_install"],
+                   @"app_install must not fire on a returning launch");
+    XCTAssertTrue([self capturedEventNamed:@"Application Opened"],
+                  @"Application Opened must still fire on every launch");
+    XCTAssertFalse([self capturedEventNamed:@"Application Installed"],
+                   @"The old Application Installed event name must never fire");
+#endif
+}
+
+@end

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -6,6 +6,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <objc/runtime.h>
 #import "FPAnalytics.h"
 #import "FPAnalyticsConfiguration.h"
 #import "FPMiddleware.h"
@@ -16,13 +17,25 @@
 #pragma mark - Test-only extensions
 // ---------------------------------------------------------------------------
 
-/// Exposes the private lifecycle handler and the DEBUG ATT status injectable.
+/// Exposes the private lifecycle handler and the ATT status injectable.
 @interface FPAnalytics (FPInstallTesting)
-#ifdef DEBUG
-// Mirrors the private-extension declaration in FPAnalytics.m — keep both exactly in sync.
 @property (atomic, copy, nullable) NSUInteger (^fp_attStatusProvider)(void);
-#endif
 - (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
+@end
+
+@implementation FPAnalytics (FPInstallTesting)
+
+- (void)setFp_attStatusProvider:(NSUInteger (^)(void))fp_attStatusProvider {
+    objc_setAssociatedObject(self,
+        @selector(fp_attStatusProvider),
+        fp_attStatusProvider,
+        OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (NSUInteger (^)(void))fp_attStatusProvider {
+    return objc_getAssociatedObject(self, @selector(fp_attStatusProvider));
+}
+
 @end
 
 // ---------------------------------------------------------------------------

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -12,6 +12,11 @@
 #import "FPMiddleware.h"
 #import "FPContext.h"
 #import "FPTrackPayload.h"
+#import "FPATTTestConstants.h"
+
+// NSUserDefaults keys — defined in FPAnalytics.m, declared here for test access.
+extern NSString *const FPVersionKey;
+extern NSString *const FPBuildKeyV2;
 
 // ---------------------------------------------------------------------------
 #pragma mark - Test-only extensions
@@ -66,19 +71,11 @@
 @end
 
 // ---------------------------------------------------------------------------
-#pragma mark - ATT status constants
+#pragma mark - Test IDFA fixtures
 // ---------------------------------------------------------------------------
-
-static const NSUInteger kFPATTNotDetermined = 0;
-static const NSUInteger kFPATTDenied        = 2;
-static const NSUInteger kFPATTAuthorized    = 3;
 
 static NSString *const kFPValidIDFA  = @"12345678-1234-1234-1234-123456789ABC";
 static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
-
-// NSUserDefaults keys (match the constants defined in FPAnalytics.m)
-static NSString *const kFPBuildKeyV2  = @"FPBuildKeyV2";
-static NSString *const kFPVersionKey  = @"FPVersionKey";
 
 // ---------------------------------------------------------------------------
 #pragma mark - Test class
@@ -100,12 +97,12 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     [super setUp];
 
     // Persist original NSUserDefaults state so tearDown can restore it exactly.
-    self.savedBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
-    self.savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:kFPVersionKey];
+    self.savedBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2];
+    self.savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:FPVersionKey];
 
     // Simulate a fresh install by removing the guard flag.
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPBuildKeyV2];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPVersionKey];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPVersionKey];
 
     // Build a configuration that fires lifecycle events but does NOT hook into
     // UIApplication (no notifications registered — tests drive the method directly).
@@ -123,14 +120,14 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
     // Restore NSUserDefaults to the state before this test.
     if (self.savedBuildV2) {
-        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:kFPBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:FPBuildKeyV2];
     } else {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPBuildKeyV2];
     }
     if (self.savedVersion) {
-        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:kFPVersionKey];
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:FPVersionKey];
     } else {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPVersionKey];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPVersionKey];
     }
     [[NSUserDefaults standardUserDefaults] synchronize];
 
@@ -192,8 +189,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IOS
     // Seed the guard flag to simulate a returning user.
-    [[NSUserDefaults standardUserDefaults] setObject:@"1.0" forKey:kFPBuildKeyV2];
-    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:kFPVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1.0" forKey:FPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:FPVersionKey];
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
@@ -213,7 +210,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testPayloadContainsRequiredFields
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTNotDetermined; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTNotDetermined; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
@@ -265,7 +262,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAIncludedWhenATTAuthorized
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTAuthorized; };
     self.configuration.adSupportBlock   = ^NSString *{ return kFPValidIDFA; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -283,7 +280,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAAbsentWhenATTNotAuthorized
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTDenied; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTDenied; };
     self.configuration.adSupportBlock   = ^NSString *{ return kFPValidIDFA; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -301,7 +298,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAAbsentWhenAdSupportBlockNil
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTAuthorized; };
     // adSupportBlock intentionally not set — remains nil
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -319,7 +316,7 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 - (void)testIDFAAbsentWhenZeroedIDFA
 {
 #if TARGET_OS_IOS
-    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kATTAuthorized; };
     self.configuration.adSupportBlock   = ^NSString *{ return kFPZeroIDFA; };
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
@@ -343,13 +340,13 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IOS
     // Guard: key must be absent before the call.
-    XCTAssertNil([[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2],
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2],
                  @"Pre-condition: FPBuildKeyV2 must be nil before first launch");
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     // No flush called — flag must already be set.
-    NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
+    NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2];
     XCTAssertNotNil(storedBuild,
                     @"FPBuildKeyV2 must be written immediately after app_install is enqueued, not deferred to flush");
 #else
@@ -366,8 +363,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IOS
     // Seed guard flag so this looks like a returning launch with an updated build.
-    [[NSUserDefaults standardUserDefaults] setObject:@"0.9" forKey:kFPBuildKeyV2];
-    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:kFPVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:@"0.9" forKey:FPBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:FPVersionKey];
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -19,7 +19,8 @@
 /// Exposes the private lifecycle handler and the DEBUG ATT status injectable.
 @interface FPAnalytics (FPInstallTesting)
 #ifdef DEBUG
-@property (nonatomic, copy, nullable) NSUInteger (^fp_attStatusProvider)(void);
+// Mirrors the private-extension declaration in FPAnalytics.m — keep both exactly in sync.
+@property (atomic, copy, nullable) NSUInteger (^fp_attStatusProvider)(void);
 #endif
 - (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 @end
@@ -164,6 +165,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 
     XCTAssertTrue([self capturedEventNamed:@"app_install"],
                   @"app_install must fire when FPBuildKeyV2 is absent (first install)");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -183,6 +186,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 
     XCTAssertFalse([self capturedEventNamed:@"app_install"],
                    @"app_install must NOT fire when FPBuildKeyV2 is already set");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -234,6 +239,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
 
     // app_version — non-nil (may be empty in test bundle)
     XCTAssertNotNil(props[@"app_version"], @"app_version key must be present");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -254,6 +261,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     XCTAssertNotNil(payload, @"app_install payload must be captured");
     XCTAssertEqualObjects(payload.properties[@"idfa"], kFPValidIDFA,
                           @"idfa must be present and match when ATT is authorized");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -270,6 +279,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     XCTAssertNotNil(payload, @"app_install payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when ATT status is not authorized");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -286,6 +297,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     XCTAssertNotNil(payload, @"app_install payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when adSupportBlock is nil even if ATT is authorized");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -302,6 +315,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     XCTAssertNotNil(payload, @"app_install payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when adSupportBlock returns all-zeros IDFA");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -324,6 +339,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:kFPBuildKeyV2];
     XCTAssertNotNil(storedBuild,
                     @"FPBuildKeyV2 must be written immediately after app_install is enqueued, not deferred to flush");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 
@@ -350,6 +367,8 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
                   @"Application Opened must still fire on every launch");
     XCTAssertFalse([self capturedEventNamed:@"Application Installed"],
                    @"The old Application Installed event name must never fire");
+#else
+    XCTSkip(@"This test requires iOS");
 #endif
 }
 

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -18,7 +18,9 @@
 
 /// Exposes the private lifecycle handler and the DEBUG ATT status injectable.
 @interface FPAnalytics (FPInstallTesting)
+#ifdef DEBUG
 @property (nonatomic, copy, nullable) NSUInteger (^fp_attStatusProvider)(void);
+#endif
 - (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 @end
 
@@ -268,6 +270,22 @@ static NSString *const kFPVersionKey  = @"FPVersionKey";
     XCTAssertNotNil(payload, @"app_install payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when ATT status is not authorized");
+#endif
+}
+
+/// idfa must NOT appear when ATT is authorized but adSupportBlock is nil.
+- (void)testIDFAAbsentWhenAdSupportBlockNil
+{
+#if TARGET_OS_IOS
+    self.analytics.fp_attStatusProvider = ^NSUInteger { return kFPATTAuthorized; };
+    // adSupportBlock intentionally not set — remains nil
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *payload = [self capturedInstallPayload];
+    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNil(payload.properties[@"idfa"],
+                 @"idfa must be absent when adSupportBlock is nil even if ATT is authorized");
 #endif
 }
 

--- a/FreshpaintTests/FPAppleAdsAttributionTests.m
+++ b/FreshpaintTests/FPAppleAdsAttributionTests.m
@@ -164,6 +164,17 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     return nil;
 }
 
+/// Creates a fresh FPAnalytics instance with the current configuration and a new capture middleware.
+/// Clears the install guard so the fresh-install path fires.
+- (FPAnalytics *)freshAnalyticsWithCapture:(FPAppleAdsEventCapture **)outCapture
+{
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    FPAppleAdsEventCapture *cap = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ cap ];
+    if (outCapture) *outCapture = cap;
+    return [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+}
+
 // ---------------------------------------------------------------------------
 #pragma mark - AC-1, AC-2: Token capture and inclusion in payload
 // ---------------------------------------------------------------------------
@@ -269,10 +280,8 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IPHONE
     self.configuration.skanConversionValue = -1;
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
-    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
-    self.configuration.sourceMiddleware = @[ capture2 ];
-    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    FPAppleAdsEventCapture *cap = nil;
+    FPAnalytics *analytics2 = [self freshAnalyticsWithCapture:&cap];
 
     __block BOOL skanCalled = NO;
     analytics2.fp_skanCallInterceptor = ^(NSInteger value, NSString *version) {
@@ -291,10 +300,8 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IPHONE
     self.configuration.skanConversionValue = 64;
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
-    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
-    self.configuration.sourceMiddleware = @[ capture2 ];
-    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    FPAppleAdsEventCapture *cap = nil;
+    FPAnalytics *analytics2 = [self freshAnalyticsWithCapture:&cap];
 
     __block BOOL skanCalled = NO;
     analytics2.fp_skanVersionOverride = @4;
@@ -318,10 +325,8 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IPHONE
     self.configuration.skanConversionValue = 7;
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
-    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
-    self.configuration.sourceMiddleware = @[ capture2 ];
-    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    FPAppleAdsEventCapture *cap = nil;
+    FPAnalytics *analytics2 = [self freshAnalyticsWithCapture:&cap];
     analytics2.fp_skanVersionOverride = @4;
 
     __block NSInteger capturedValue = -1;
@@ -348,10 +353,8 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IPHONE
     self.configuration.skanConversionValue = 5;
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
-    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
-    self.configuration.sourceMiddleware = @[ capture2 ];
-    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    FPAppleAdsEventCapture *cap = nil;
+    FPAnalytics *analytics2 = [self freshAnalyticsWithCapture:&cap];
     analytics2.fp_skanVersionOverride = @3;
 
     __block NSInteger capturedValue = -1;
@@ -369,6 +372,25 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 #endif
 }
 
+/// Exercises the real NSInvocation code path (no interceptor) to verify retainArguments
+/// prevents dangling block pointers. SKAdNetwork may not be available in the test
+/// environment, so this only asserts no crash -- the SKAN call silently no-ops when
+/// the framework is absent.
+- (void)testSKANRealInvocationPathNoCrash
+{
+#if TARGET_OS_IPHONE
+    self.configuration.skanConversionValue = 10;
+    FPAppleAdsEventCapture *cap = nil;
+    FPAnalytics *analytics2 = [self freshAnalyticsWithCapture:&cap];
+    analytics2.fp_skanVersionOverride = @4;
+    // No interceptor -- exercises the real fp_skanInvocation + fp_skanSetCompletionHandler path.
+
+    XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
+        @"Real SKAN NSInvocation path must not crash");
+    analytics2 = nil;
+#endif
+}
+
 // ---------------------------------------------------------------------------
 #pragma mark - AC-11: skadnetwork_id must not appear in payload
 // ---------------------------------------------------------------------------
@@ -378,15 +400,13 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IPHONE
     self.configuration.skanConversionValue = 5;
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
-    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
-    self.configuration.sourceMiddleware = @[ capture2 ];
-    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    FPAppleAdsEventCapture *cap = nil;
+    FPAnalytics *analytics2 = [self freshAnalyticsWithCapture:&cap];
     analytics2.fp_appleAdsTokenProvider = ^NSString * { return @"some_token"; };
 
     [analytics2 _applicationDidFinishLaunchingWithOptions:nil];
 
-    for (FPContext *ctx in capture2.capturedContexts) {
+    for (FPContext *ctx in cap.capturedContexts) {
         FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
         if ([track isKindOfClass:[FPTrackPayload class]]) {
             XCTAssertNil(track.properties[@"skadnetwork_id"],

--- a/FreshpaintTests/FPAppleAdsAttributionTests.m
+++ b/FreshpaintTests/FPAppleAdsAttributionTests.m
@@ -238,14 +238,12 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     XCTAssertEqual(self.configuration.skanConversionValue, 0,
         @"skanConversionValue default must be 0");
 
-    __block BOOL skanCalled = NO;
     // Inject a version override so the call would be routed if it fired.
     self.analytics.fp_skanVersionOverride = @4;
     // We can't intercept the real SKAN call directly, but if value=0 the guard
     // prevents the call reaching fp_registerSKANConversionValue: at all.
     // Verify no crash and that the install event still fires normally.
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
-    (void)skanCalled;
 
     FPTrackPayload *install = [self capturedInstallPayload];
     XCTAssertNotNil(install, @"app_install must still fire when SKAN is skipped");
@@ -321,18 +319,23 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 - (void)testSkadnetworkIdAbsentFromAllPayloads
 {
 #if TARGET_OS_IPHONE
-    self.analytics.fp_appleAdsTokenProvider = ^NSString * { return @"some_token"; };
     self.configuration.skanConversionValue = 5;
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ capture2 ];
+    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    analytics2.fp_appleAdsTokenProvider = ^NSString * { return @"some_token"; };
 
-    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+    [analytics2 _applicationDidFinishLaunchingWithOptions:nil];
 
-    for (FPContext *ctx in self.capture.capturedContexts) {
+    for (FPContext *ctx in capture2.capturedContexts) {
         FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
         if ([track isKindOfClass:[FPTrackPayload class]]) {
             XCTAssertNil(track.properties[@"skadnetwork_id"],
                 @"skadnetwork_id must never appear in any event payload (event: %@)", track.event);
         }
     }
+    analytics2 = nil;
 #endif
 }
 

--- a/FreshpaintTests/FPAppleAdsAttributionTests.m
+++ b/FreshpaintTests/FPAppleAdsAttributionTests.m
@@ -169,6 +169,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 - (FPAnalytics *)freshAnalyticsWithCapture:(FPAppleAdsEventCapture **)outCapture
 {
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_VersionKey];
     FPAppleAdsEventCapture *cap = [[FPAppleAdsEventCapture alloc] init];
     self.configuration.sourceMiddleware = @[ cap ];
     if (outCapture) *outCapture = cap;

--- a/FreshpaintTests/FPAppleAdsAttributionTests.m
+++ b/FreshpaintTests/FPAppleAdsAttributionTests.m
@@ -23,6 +23,8 @@
 @property (atomic, copy, nullable) NSString *(^fp_appleAdsTokenProvider)(void);
 /// Override for fp_skanVersionOverride: @4 forces SKAN v4, @3 forces SKAN v3.
 @property (atomic, strong, nullable) NSNumber *fp_skanVersionOverride;
+/// Interceptor called instead of the real SKAN API. Args: (conversionValue, apiVersion).
+@property (atomic, copy, nullable) void (^fp_skanCallInterceptor)(NSInteger, NSString *);
 - (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 @end
 
@@ -48,6 +50,17 @@
 
 - (NSNumber *)fp_skanVersionOverride {
     return objc_getAssociatedObject(self, @selector(fp_skanVersionOverride));
+}
+
+- (void)setFp_skanCallInterceptor:(void (^)(NSInteger, NSString *))fp_skanCallInterceptor {
+    objc_setAssociatedObject(self,
+        @selector(fp_skanCallInterceptor),
+        fp_skanCallInterceptor,
+        OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (void (^)(NSInteger, NSString *))fp_skanCallInterceptor {
+    return objc_getAssociatedObject(self, @selector(fp_skanCallInterceptor));
 }
 
 @end
@@ -234,17 +247,18 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 - (void)testSKANSkippedWhenValueIsZero
 {
 #if TARGET_OS_IPHONE
-    // skanConversionValue defaults to 0 — no explicit set needed.
     XCTAssertEqual(self.configuration.skanConversionValue, 0,
         @"skanConversionValue default must be 0");
 
-    // Inject a version override so the call would be routed if it fired.
+    __block BOOL skanCalled = NO;
     self.analytics.fp_skanVersionOverride = @4;
-    // We can't intercept the real SKAN call directly, but if value=0 the guard
-    // prevents the call reaching fp_registerSKANConversionValue: at all.
-    // Verify no crash and that the install event still fires normally.
+    self.analytics.fp_skanCallInterceptor = ^(NSInteger value, NSString *version) {
+        skanCalled = YES;
+    };
+
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
+    XCTAssertFalse(skanCalled, @"SKAN must not be called when skanConversionValue is 0");
     FPTrackPayload *install = [self capturedInstallPayload];
     XCTAssertNotNil(install, @"app_install must still fire when SKAN is skipped");
 #endif
@@ -255,14 +269,42 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 {
 #if TARGET_OS_IPHONE
     self.configuration.skanConversionValue = -1;
-    // Re-create analytics with updated config.
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
     FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
     self.configuration.sourceMiddleware = @[ capture2 ];
     FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
 
+    __block BOOL skanCalled = NO;
+    analytics2.fp_skanCallInterceptor = ^(NSInteger value, NSString *version) {
+        skanCalled = YES;
+    };
+
     XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
         @"Negative skanConversionValue must not crash");
+    XCTAssertFalse(skanCalled, @"SKAN must not be called when skanConversionValue is negative");
+    analytics2 = nil;
+#endif
+}
+
+/// skanConversionValue > 63 → SKAN registration skipped (out of valid range).
+- (void)testSKANSkippedWhenValueExceedsMaximum
+{
+#if TARGET_OS_IPHONE
+    self.configuration.skanConversionValue = 64;
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ capture2 ];
+    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+
+    __block BOOL skanCalled = NO;
+    analytics2.fp_skanVersionOverride = @4;
+    analytics2.fp_skanCallInterceptor = ^(NSInteger value, NSString *version) {
+        skanCalled = YES;
+    };
+
+    XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
+        @"skanConversionValue > 63 must not crash");
+    XCTAssertFalse(skanCalled, @"SKAN must not be called when skanConversionValue > 63");
     analytics2 = nil;
 #endif
 }
@@ -271,7 +313,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 #pragma mark - AC-7, AC-8: SKAN v4 on iOS 16.1+
 // ---------------------------------------------------------------------------
 
-/// skanConversionValue > 0 with v4 override → SKAdNetwork v4 selector invoked without crash.
+/// skanConversionValue > 0 with v4 override → SKAdNetwork v4 called with correct value.
 - (void)testSKANv4CalledWithConfiguredValue
 {
 #if TARGET_OS_IPHONE
@@ -282,10 +324,17 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
     analytics2.fp_skanVersionOverride = @4;
 
-    // The real SKAdNetwork v4 selector is available on iOS 16.1+; on the simulator
-    // the call should complete without crashing regardless of whether postbacks fire.
+    __block NSInteger capturedValue = -1;
+    __block NSString *capturedVersion = nil;
+    analytics2.fp_skanCallInterceptor = ^(NSInteger value, NSString *version) {
+        capturedValue = value;
+        capturedVersion = version;
+    };
+
     XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
         @"SKAN v4 registration must not crash when skanConversionValue > 0");
+    XCTAssertEqual(capturedValue, 7, @"SKAN must receive the configured conversion value");
+    XCTAssertEqualObjects(capturedVersion, @"v4", @"SKAN must use v4 API when override is @4");
     analytics2 = nil;
 #endif
 }
@@ -294,7 +343,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 #pragma mark - AC-9: SKAN v3 fallback
 // ---------------------------------------------------------------------------
 
-/// skanConversionValue > 0 with v3 override → SKAdNetwork v3 selector invoked without crash.
+/// skanConversionValue > 0 with v3 override → SKAdNetwork v3 called with correct value.
 - (void)testSKANv3FallbackCalledWithConfiguredValue
 {
 #if TARGET_OS_IPHONE
@@ -305,8 +354,17 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
     analytics2.fp_skanVersionOverride = @3;
 
+    __block NSInteger capturedValue = -1;
+    __block NSString *capturedVersion = nil;
+    analytics2.fp_skanCallInterceptor = ^(NSInteger value, NSString *version) {
+        capturedValue = value;
+        capturedVersion = version;
+    };
+
     XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
         @"SKAN v3 registration must not crash when skanConversionValue > 0");
+    XCTAssertEqual(capturedValue, 5, @"SKAN must receive the configured conversion value");
+    XCTAssertEqualObjects(capturedVersion, @"v3", @"SKAN must use v3 API when override is @3");
     analytics2 = nil;
 #endif
 }

--- a/FreshpaintTests/FPAppleAdsAttributionTests.m
+++ b/FreshpaintTests/FPAppleAdsAttributionTests.m
@@ -1,0 +1,339 @@
+//
+//  FPAppleAdsAttributionTests.m
+//  FreshpaintTests
+//
+//  Unit tests for FRP-39: Apple Ads attribution token and SKAdNetwork conversion value.
+//
+
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+#import "FPAnalytics.h"
+#import "FPAnalyticsConfiguration.h"
+#import "FPMiddleware.h"
+#import "FPContext.h"
+#import "FPTrackPayload.h"
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test-only extensions
+// ---------------------------------------------------------------------------
+
+/// Exposes the private lifecycle handler and test seam properties.
+@interface FPAnalytics (FPAppleAdsTesting)
+/// Override for fp_appleAdsTokenProvider: return a token string or throw to simulate failure.
+@property (atomic, copy, nullable) NSString *(^fp_appleAdsTokenProvider)(void);
+/// Override for fp_skanVersionOverride: @4 forces SKAN v4, @3 forces SKAN v3.
+@property (atomic, strong, nullable) NSNumber *fp_skanVersionOverride;
+- (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
+@end
+
+@implementation FPAnalytics (FPAppleAdsTesting)
+
+- (void)setFp_appleAdsTokenProvider:(NSString *(^)(void))fp_appleAdsTokenProvider {
+    objc_setAssociatedObject(self,
+        @selector(fp_appleAdsTokenProvider),
+        fp_appleAdsTokenProvider,
+        OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (NSString *(^)(void))fp_appleAdsTokenProvider {
+    return objc_getAssociatedObject(self, @selector(fp_appleAdsTokenProvider));
+}
+
+- (void)setFp_skanVersionOverride:(NSNumber *)fp_skanVersionOverride {
+    objc_setAssociatedObject(self,
+        @selector(fp_skanVersionOverride),
+        fp_skanVersionOverride,
+        OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSNumber *)fp_skanVersionOverride {
+    return objc_getAssociatedObject(self, @selector(fp_skanVersionOverride));
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - Capture middleware
+// ---------------------------------------------------------------------------
+
+@interface FPAppleAdsEventCapture : NSObject <FPMiddleware>
+@property (nonatomic, readonly, strong) NSMutableArray<FPContext *> *capturedContexts;
+@end
+
+@implementation FPAppleAdsEventCapture
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _capturedContexts = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)context:(FPContext *)context next:(FPMiddlewareNext)next
+{
+    [_capturedContexts addObject:context];
+    next(context);
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - NSUserDefaults key constants (match FPAnalytics.m)
+// ---------------------------------------------------------------------------
+
+static NSString *const kFPAA_BuildKeyV2  = @"FPBuildKeyV2";
+static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test class
+// ---------------------------------------------------------------------------
+
+@interface FPAppleAdsAttributionTests : XCTestCase
+@property (nonatomic, strong) FPAnalyticsConfiguration *configuration;
+@property (nonatomic, strong) FPAnalytics              *analytics;
+@property (nonatomic, strong) FPAppleAdsEventCapture   *capture;
+@property (nonatomic, copy, nullable) NSString         *savedBuildV2;
+@property (nonatomic, copy, nullable) NSString         *savedVersion;
+@end
+
+@implementation FPAppleAdsAttributionTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.savedBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:kFPAA_BuildKeyV2];
+    self.savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:kFPAA_VersionKey];
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_VersionKey];
+
+    self.configuration = [FPAnalyticsConfiguration configurationWithWriteKey:@"TEST_WRITE_KEY"];
+    self.configuration.trackApplicationLifecycleEvents = YES;
+    self.configuration.application = nil;
+
+    self.capture = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ self.capture ];
+
+    self.analytics = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+}
+
+- (void)tearDown
+{
+    if (self.savedBuildV2) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:kFPAA_BuildKeyV2];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    }
+    if (self.savedVersion) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:kFPAA_VersionKey];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_VersionKey];
+    }
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    self.analytics     = nil;
+    self.capture       = nil;
+    self.configuration = nil;
+    [super tearDown];
+}
+
+- (nullable FPTrackPayload *)capturedInstallPayload
+{
+    for (FPContext *ctx in self.capture.capturedContexts) {
+        FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
+        if ([track isKindOfClass:[FPTrackPayload class]] &&
+            [track.event isEqualToString:@"app_install"]) {
+            return track;
+        }
+    }
+    return nil;
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC-1, AC-2: Token capture and inclusion in payload
+// ---------------------------------------------------------------------------
+
+/// Apple Ads token returned by provider → included as apple_ads_token in app_install payload.
+- (void)testAppleAdsTokenIncludedInPayload
+{
+#if TARGET_OS_IPHONE
+    static NSString *const kTestToken = @"TEST_APPLE_ADS_TOKEN_ABC123";
+    self.analytics.fp_appleAdsTokenProvider = ^NSString * { return kTestToken; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *install = [self capturedInstallPayload];
+    XCTAssertNotNil(install, @"app_install event must be tracked on fresh install");
+    XCTAssertEqualObjects(install.properties[@"apple_ads_token"], kTestToken,
+        @"apple_ads_token must be set to the value returned by attributionToken:");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC-3, AC-4: Graceful failure and @try/@catch
+// ---------------------------------------------------------------------------
+
+/// Provider throws ObjC exception → no crash, apple_ads_token absent from payload.
+- (void)testAppleAdsTokenExceptionNoCrash
+{
+#if TARGET_OS_IPHONE
+    self.analytics.fp_appleAdsTokenProvider = ^NSString * {
+        @throw [NSException exceptionWithName:@"AAAttributionException"
+                                       reason:@"Not installed via Apple Search Ads"
+                                     userInfo:nil];
+        return nil;
+    };
+
+    XCTAssertNoThrow(
+        [self.analytics _applicationDidFinishLaunchingWithOptions:nil],
+        @"attributionToken: exception must be caught — must not propagate to caller"
+    );
+
+    FPTrackPayload *install = [self capturedInstallPayload];
+    XCTAssertNotNil(install, @"app_install must still fire even when token throws");
+    XCTAssertNil(install.properties[@"apple_ads_token"],
+        @"apple_ads_token must be absent when token retrieval throws");
+#endif
+}
+
+/// Provider returns nil → apple_ads_token absent from payload.
+- (void)testAppleAdsTokenNilAbsentFromPayload
+{
+#if TARGET_OS_IPHONE
+    self.analytics.fp_appleAdsTokenProvider = ^NSString * { return nil; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *install = [self capturedInstallPayload];
+    XCTAssertNil(install.properties[@"apple_ads_token"],
+        @"apple_ads_token must be absent when token is nil");
+#endif
+}
+
+/// Provider returns empty string → apple_ads_token absent from payload.
+- (void)testAppleAdsTokenEmptyStringAbsentFromPayload
+{
+#if TARGET_OS_IPHONE
+    self.analytics.fp_appleAdsTokenProvider = ^NSString * { return @""; };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *install = [self capturedInstallPayload];
+    XCTAssertNil(install.properties[@"apple_ads_token"],
+        @"apple_ads_token must be absent when token is empty string");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC-5, AC-6, AC-10: SKAN opt-in / skip
+// ---------------------------------------------------------------------------
+
+/// skanConversionValue = 0 (default) → SKAN registration skipped entirely.
+- (void)testSKANSkippedWhenValueIsZero
+{
+#if TARGET_OS_IPHONE
+    // skanConversionValue defaults to 0 — no explicit set needed.
+    XCTAssertEqual(self.configuration.skanConversionValue, 0,
+        @"skanConversionValue default must be 0");
+
+    __block BOOL skanCalled = NO;
+    // Inject a version override so the call would be routed if it fired.
+    self.analytics.fp_skanVersionOverride = @4;
+    // We can't intercept the real SKAN call directly, but if value=0 the guard
+    // prevents the call reaching fp_registerSKANConversionValue: at all.
+    // Verify no crash and that the install event still fires normally.
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+    (void)skanCalled;
+
+    FPTrackPayload *install = [self capturedInstallPayload];
+    XCTAssertNotNil(install, @"app_install must still fire when SKAN is skipped");
+#endif
+}
+
+/// skanConversionValue < 0 → SKAN registration skipped.
+- (void)testSKANSkippedWhenValueIsNegative
+{
+#if TARGET_OS_IPHONE
+    self.configuration.skanConversionValue = -1;
+    // Re-create analytics with updated config.
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ capture2 ];
+    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+
+    XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
+        @"Negative skanConversionValue must not crash");
+    analytics2 = nil;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC-7, AC-8: SKAN v4 on iOS 16.1+
+// ---------------------------------------------------------------------------
+
+/// skanConversionValue > 0 with v4 override → SKAdNetwork v4 selector invoked without crash.
+- (void)testSKANv4CalledWithConfiguredValue
+{
+#if TARGET_OS_IPHONE
+    self.configuration.skanConversionValue = 7;
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ capture2 ];
+    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    analytics2.fp_skanVersionOverride = @4;
+
+    // The real SKAdNetwork v4 selector is available on iOS 16.1+; on the simulator
+    // the call should complete without crashing regardless of whether postbacks fire.
+    XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
+        @"SKAN v4 registration must not crash when skanConversionValue > 0");
+    analytics2 = nil;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC-9: SKAN v3 fallback
+// ---------------------------------------------------------------------------
+
+/// skanConversionValue > 0 with v3 override → SKAdNetwork v3 selector invoked without crash.
+- (void)testSKANv3FallbackCalledWithConfiguredValue
+{
+#if TARGET_OS_IPHONE
+    self.configuration.skanConversionValue = 5;
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPAA_BuildKeyV2];
+    FPAppleAdsEventCapture *capture2 = [[FPAppleAdsEventCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ capture2 ];
+    FPAnalytics *analytics2 = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+    analytics2.fp_skanVersionOverride = @3;
+
+    XCTAssertNoThrow([analytics2 _applicationDidFinishLaunchingWithOptions:nil],
+        @"SKAN v3 registration must not crash when skanConversionValue > 0");
+    analytics2 = nil;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - AC-11: skadnetwork_id must not appear in payload
+// ---------------------------------------------------------------------------
+
+/// No payload field named skadnetwork_id in any tracked event.
+- (void)testSkadnetworkIdAbsentFromAllPayloads
+{
+#if TARGET_OS_IPHONE
+    self.analytics.fp_appleAdsTokenProvider = ^NSString * { return @"some_token"; };
+    self.configuration.skanConversionValue = 5;
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    for (FPContext *ctx in self.capture.capturedContexts) {
+        FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
+        if ([track isKindOfClass:[FPTrackPayload class]]) {
+            XCTAssertNil(track.properties[@"skadnetwork_id"],
+                @"skadnetwork_id must never appear in any event payload (event: %@)", track.event);
+        }
+    }
+#endif
+}
+
+@end

--- a/FreshpaintTests/FPDeepLinkAttributionTests.m
+++ b/FreshpaintTests/FPDeepLinkAttributionTests.m
@@ -1,0 +1,484 @@
+//
+//  FPDeepLinkAttributionTests.m
+//  FreshpaintTests
+//
+//  FRP-38: Unit tests for deep link attribution — ad click IDs and UTM params.
+//
+
+#import <XCTest/XCTest.h>
+#import "FPAnalytics.h"
+#import "FPAnalyticsConfiguration.h"
+#import "FPMiddleware.h"
+#import "FPContext.h"
+#import "FPTrackPayload.h"
+#import "FPAdClickIds.h"
+#import "FPState.h"
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test-only extensions
+// ---------------------------------------------------------------------------
+
+@interface FPAnalytics (FPDeepLinkTesting)
+- (void)_applicationDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - Capture middleware
+// ---------------------------------------------------------------------------
+
+@interface FPDeepLinkCapture : NSObject <FPMiddleware>
+@property (nonatomic, readonly, strong) NSMutableArray<FPContext *> *capturedContexts;
+@end
+
+@implementation FPDeepLinkCapture
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _capturedContexts = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)context:(FPContext *)context next:(FPMiddlewareNext)next
+{
+    [_capturedContexts addObject:context];
+    next(context);
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+#pragma mark - NSUserDefaults keys (match FPAnalytics.m)
+// ---------------------------------------------------------------------------
+
+static NSString *const kFPDLBuildKeyV2  = @"FPBuildKeyV2";
+static NSString *const kFPDLVersionKey  = @"FPVersionKey";
+static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test class
+// ---------------------------------------------------------------------------
+
+@interface FPDeepLinkAttributionTests : XCTestCase
+@property (nonatomic, strong) FPAnalyticsConfiguration *configuration;
+@property (nonatomic, strong) FPAnalytics              *analytics;
+@property (nonatomic, strong) FPDeepLinkCapture        *capture;
+// Saved NSUserDefaults values — restored in tearDown.
+@property (nonatomic, copy, nullable) NSString         *savedBuildV2;
+@property (nonatomic, copy, nullable) NSString         *savedVersion;
+@property (nonatomic, copy, nullable) NSData           *savedClickIds;
+@end
+
+@implementation FPDeepLinkAttributionTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Save and clear persistent state that may affect tests.
+    self.savedBuildV2  = [[NSUserDefaults standardUserDefaults] stringForKey:kFPDLBuildKeyV2];
+    self.savedVersion  = [[NSUserDefaults standardUserDefaults] stringForKey:kFPDLVersionKey];
+    self.savedClickIds = [[NSUserDefaults standardUserDefaults] dataForKey:kFPClickIdsKey];
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPDLBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPDLVersionKey];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPClickIdsKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    // Also clear in-memory state on the shared FPState singleton.
+    [FPState sharedInstance].userInfo.clickIds          = nil;
+    [FPState sharedInstance].userInfo.utmParams         = nil;
+    [FPState sharedInstance].userInfo.utmExpiryTimestamp = 0;
+
+    self.configuration = [FPAnalyticsConfiguration configurationWithWriteKey:@"TEST_WRITE_KEY"];
+    self.configuration.trackApplicationLifecycleEvents = YES;
+    self.configuration.trackDeepLinks = YES;
+    self.configuration.application    = nil;
+
+    self.capture = [[FPDeepLinkCapture alloc] init];
+    self.configuration.sourceMiddleware = @[ self.capture ];
+
+    self.analytics = [[FPAnalytics alloc] initWithConfiguration:self.configuration];
+}
+
+- (void)tearDown
+{
+    // Restore NSUserDefaults.
+    if (self.savedBuildV2) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedBuildV2 forKey:kFPDLBuildKeyV2];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPDLBuildKeyV2];
+    }
+    if (self.savedVersion) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedVersion forKey:kFPDLVersionKey];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPDLVersionKey];
+    }
+    if (self.savedClickIds) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedClickIds forKey:kFPClickIdsKey];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPClickIdsKey];
+    }
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    // Clear in-memory state.
+    [FPState sharedInstance].userInfo.clickIds           = nil;
+    [FPState sharedInstance].userInfo.utmParams          = nil;
+    [FPState sharedInstance].userInfo.utmExpiryTimestamp = 0;
+
+    self.analytics     = nil;
+    self.capture       = nil;
+    self.configuration = nil;
+    [super tearDown];
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Helpers
+// ---------------------------------------------------------------------------
+
+- (nullable FPTrackPayload *)firstCapturedEventNamed:(NSString *)name
+{
+    for (FPContext *ctx in self.capture.capturedContexts) {
+        FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
+        if ([track isKindOfClass:[FPTrackPayload class]] &&
+            [track.event isEqualToString:name]) {
+            return track;
+        }
+    }
+    return nil;
+}
+
+- (BOOL)capturedEventNamed:(NSString *)name
+{
+    return [self firstCapturedEventNamed:name] != nil;
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 1: All 24 click ID keys extracted
+// ---------------------------------------------------------------------------
+
+- (void)testAllClickIdKeysExtracted
+{
+    NSString *urlStr =
+        @"https://example.com/landing"
+        @"?aleid=v1&cntr_auctionId=v2&msclkid=v3&fbclid=v4&gclid=v5"
+        @"&dclid=v6&gclsrc=v7&wbraid=v8&gbraid=v9&irclickid=v10"
+        @"&li_fat_id=v11&ndclid=v12&epik=v13&rdt_cid=v14&sccid=v15"
+        @"&ScCid=v16&spclid=v17&sapid=v18&ttdimp=v19&ttclid=v20"
+        @"&twclid=v21&clid_src=v22&viant_clid=v23&qclid=v24";
+    NSURL *url = [NSURL URLWithString:urlStr];
+
+    NSDictionary *result = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    NSArray<NSString *> *supported = [FPAdClickIds supportedClickIdKeys];
+    XCTAssertEqual(supported.count, 24u, @"There must be exactly 24 supported click ID keys");
+
+    // Each canonical key should appear prefixed with $ in the result.
+    // Note: sccid and ScCid both map to lowercase "sccid", so only one will win (first match).
+    // We check that at least 23 unique canonical keys got extracted (sccid and ScCid de-dup to 1).
+    NSUInteger foundCount = 0;
+    for (NSString *key in supported) {
+        NSString *prefixed = [NSString stringWithFormat:@"$%@", key];
+        if (clickIds[prefixed] != nil) {
+            foundCount++;
+        }
+    }
+    // At minimum 23 distinct canonical entries (sccid/ScCid de-dup to one).
+    XCTAssertGreaterThanOrEqual(foundCount, 23u,
+        @"At least 23 out of 24 entries should be extracted (sccid/ScCid are case-insensitive duplicates)");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 2: Click ID stored with $ prefix
+// ---------------------------------------------------------------------------
+
+- (void)testClickIdHasDollarPrefix
+{
+    NSURL *url = [NSURL URLWithString:@"https://example.com?gclid=abc123"];
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    XCTAssertNotNil(clickIds[@"$gclid"],
+                    @"$gclid must be present in clickIds");
+    XCTAssertNil(clickIds[@"gclid"],
+                 @"gclid without $ prefix must NOT be present");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 3: Creation timestamp is NSNumber with a positive value
+// ---------------------------------------------------------------------------
+
+- (void)testClickIdHasCreationTimestampMs
+{
+    NSURL *url = [NSURL URLWithString:@"https://example.com?gclid=abc123"];
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    id creationTime = clickIds[@"$gclid_creation_time"];
+    XCTAssertNotNil(creationTime, @"$gclid_creation_time must be present");
+    XCTAssertTrue([creationTime isKindOfClass:[NSNumber class]],
+                  @"$gclid_creation_time must be an NSNumber");
+    NSInteger ms = [creationTime integerValue];
+    XCTAssertGreaterThan(ms, 0, @"$gclid_creation_time must be a positive Unix timestamp in ms");
+    // Sanity: should be at least year-2020 epoch ms.
+    XCTAssertGreaterThan(ms, (NSInteger)1577836800000LL,
+                         @"$gclid_creation_time should be a plausible recent Unix ms timestamp");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 4: Google gacid captured as campaign_id
+// ---------------------------------------------------------------------------
+
+- (void)testGoogleCampaignId
+{
+    NSURL *url = [NSURL URLWithString:@"https://example.com?gclid=abc&gacid=campaign123"];
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    XCTAssertEqualObjects(clickIds[@"$gclid_campaign_id"], @"campaign123",
+                          @"$gclid_campaign_id must equal the gacid param value");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 5: Facebook extras extracted
+// ---------------------------------------------------------------------------
+
+- (void)testFacebookExtras
+{
+    NSURL *url = [NSURL URLWithString:
+        @"https://example.com?fbclid=fb1&ad_id=adA&adset_id=adsetB&campaign_id=campC"];
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    XCTAssertEqualObjects(clickIds[@"$fbclid_ad_id"],       @"adA",   @"$fbclid_ad_id must be captured");
+    XCTAssertEqualObjects(clickIds[@"$fbclid_adset_id"],    @"adsetB",@"$fbclid_adset_id must be captured");
+    XCTAssertEqualObjects(clickIds[@"$fbclid_campaign_id"], @"campC", @"$fbclid_campaign_id must be captured");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 6: Deduplication — same value does not update creation_time
+// ---------------------------------------------------------------------------
+
+- (void)testDeduplicationSameValue
+{
+    // Seed an initial click ID with a known creation_time.
+    NSInteger oldTimeMs = 1000000000000LL; // past timestamp
+    NSDictionary *initial = @{
+        @"$gclid": @"same_value",
+        @"$gclid_creation_time": @(oldTimeMs),
+    };
+    [[FPState sharedInstance] mergeClickIds:initial];
+
+    // Wait for the barrier write to complete.
+    // activeClickIdsFlattened uses dispatch_sync so it drains the queue.
+    NSDictionary *afterFirst = [[FPState sharedInstance] activeClickIdsFlattened];
+    XCTAssertEqualObjects(afterFirst[@"$gclid"], @"same_value");
+    XCTAssertEqualObjects(afterFirst[@"$gclid_creation_time"], @(oldTimeMs));
+
+    // Now merge the same key with the same value but a newer creation_time.
+    NSInteger newTimeMs = oldTimeMs + 1000;
+    NSDictionary *duplicate = @{
+        @"$gclid": @"same_value",
+        @"$gclid_creation_time": @(newTimeMs),
+    };
+    [[FPState sharedInstance] mergeClickIds:duplicate];
+
+    NSDictionary *afterSecond = [[FPState sharedInstance] activeClickIdsFlattened];
+    XCTAssertEqualObjects(afterSecond[@"$gclid_creation_time"], @(oldTimeMs),
+        @"creation_time must NOT be updated when merging the same value again (deduplication)");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 7: UTM params extracted from URL
+// ---------------------------------------------------------------------------
+
+- (void)testUTMExtraction
+{
+    NSURL *url = [NSURL URLWithString:
+        @"https://example.com?utm_source=google&utm_medium=cpc"
+        @"&utm_campaign=spring_sale&utm_term=shoes&utm_content=banner"];
+    NSDictionary *result    = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *utmParams = result[@"utmParams"];
+
+    XCTAssertEqualObjects(utmParams[@"utm_source"],   @"google",      @"utm_source must be extracted");
+    XCTAssertEqualObjects(utmParams[@"utm_medium"],   @"cpc",         @"utm_medium must be extracted");
+    XCTAssertEqualObjects(utmParams[@"utm_campaign"], @"spring_sale", @"utm_campaign must be extracted");
+    XCTAssertEqualObjects(utmParams[@"utm_term"],     @"shoes",       @"utm_term must be extracted");
+    XCTAssertEqualObjects(utmParams[@"utm_content"],  @"banner",      @"utm_content must be extracted");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 8: Active UTM params returned when freshly set
+// ---------------------------------------------------------------------------
+
+- (void)testUTMExpiryActive
+{
+    NSDictionary *params = @{ @"utm_source": @"facebook", @"utm_medium": @"social" };
+    [[FPState sharedInstance] setUTMParams:params];
+
+    NSDictionary *active = [[FPState sharedInstance] activeUTMParams];
+    XCTAssertNotNil(active, @"activeUTMParams must return non-nil when freshly set");
+    XCTAssertEqualObjects(active[@"utm_source"], @"facebook");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 9: Active UTM params return nil when expiry is in the past
+// ---------------------------------------------------------------------------
+
+- (void)testUTMExpiryExpired
+{
+    // Set UTM params (which sets expiry = now + 86400).
+    NSDictionary *params = @{ @"utm_source": @"test" };
+    [[FPState sharedInstance] setUTMParams:params];
+
+    // Forcibly expire by setting utmExpiryTimestamp to a past Unix second.
+    // The property setter goes through the state queue, so it is thread-safe.
+    [FPState sharedInstance].userInfo.utmExpiryTimestamp = 1.0;
+
+    NSDictionary *active = [[FPState sharedInstance] activeUTMParams];
+    XCTAssertNil(active,
+        @"activeUTMParams must return nil when utmExpiryTimestamp is in the past");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 10: app_install merges stored click IDs
+// ---------------------------------------------------------------------------
+
+- (void)testAppInstallMergesStoredClickIds
+{
+#if TARGET_OS_IOS
+    // Pre-store a click ID so it is available when app_install fires.
+    NSDictionary *clickId = @{
+        @"$gclid": @"install_gclid",
+        @"$gclid_creation_time": @((NSInteger)([[NSDate date] timeIntervalSince1970] * 1000)),
+    };
+    [[FPState sharedInstance] mergeClickIds:clickId];
+
+    // Drain the barrier write so the value is visible synchronously.
+    (void)[[FPState sharedInstance] activeClickIdsFlattened];
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    FPTrackPayload *installPayload = [self firstCapturedEventNamed:@"app_install"];
+    XCTAssertNotNil(installPayload, @"app_install must fire on first launch");
+    XCTAssertNotNil(installPayload.properties[@"$gclid"],
+        @"$gclid must be merged into app_install properties from stored click IDs");
+#else
+    XCTSkip(@"This test requires iOS");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 11: Payload filters applied before extraction
+// ---------------------------------------------------------------------------
+
+- (void)testPayloadFiltersAppliedBeforeExtraction
+{
+    // URL contains a fake "fb_auth_token=SECRET" query param that should be redacted
+    // before we extract anything. Use a filter that replaces the token value.
+    NSString *urlStr = @"https://example.com?fbclid=realclickid&fb_auth_token=MY_SECRET_TOKEN";
+    NSURL *url = [NSURL URLWithString:urlStr];
+
+    // Filter: replace the fb_auth_token value with REDACTED.
+    NSDictionary<NSString *, NSString *> *filters = @{
+        @"fb_auth_token=[^&]+": @"fb_auth_token=REDACTED"
+    };
+
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:filters];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    // fbclid should still be extracted (it was not filtered).
+    XCTAssertEqualObjects(clickIds[@"$fbclid"], @"realclickid",
+        @"fbclid must still be extracted after filtering");
+
+    // The token value should not appear anywhere in clickIds.
+    for (id value in clickIds.allValues) {
+        if ([value isKindOfClass:[NSString class]]) {
+            XCTAssertFalse([value containsString:@"MY_SECRET_TOKEN"],
+                @"Original token value must not appear in extracted click IDs after filtering");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 12: Deep Link Opened event still fires via openURL:
+// ---------------------------------------------------------------------------
+
+- (void)testDeepLinkOpenedStillFires
+{
+    NSURL *url = [NSURL URLWithString:@"myapp://landing?gclid=x123"];
+    [self.analytics openURL:url options:@{}];
+
+    XCTAssertTrue([self capturedEventNamed:@"Deep Link Opened"],
+        @"Deep Link Opened must still fire when openURL:options: is called");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 13: Snapchat both variants handled without crash
+// ---------------------------------------------------------------------------
+
+- (void)testSnapchatBothVariantsExtracted
+{
+    // Both sccid (lowercase) and ScCid (mixed-case) in the same URL.
+    // Case-insensitive matching means they both map to the same canonical key;
+    // first-match wins and the second is ignored. No crash must occur.
+    NSURL *url = [NSURL URLWithString:@"https://example.com?sccid=snap1&ScCid=snap2"];
+    NSDictionary *result = nil;
+    XCTAssertNoThrow(result = [FPAdClickIds extractFromURL:url payloadFilters:@{}],
+        @"Extraction with both sccid and ScCid variants must not throw");
+
+    NSDictionary *clickIds = result[@"clickIds"];
+    // At least one of the two canonical forms must be present.
+    BOOL eitherFound = (clickIds[@"$sccid"] != nil || clickIds[@"$ScCid"] != nil);
+    XCTAssertTrue(eitherFound,
+        @"At least one of $sccid or $ScCid must be present in the result");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 14: Click IDs persist to NSUserDefaults after mergeClickIds
+// ---------------------------------------------------------------------------
+
+- (void)testClickIdsPersistAfterMerge
+{
+    NSInteger nowMs = (NSInteger)([[NSDate date] timeIntervalSince1970] * 1000);
+    NSDictionary *clickId = @{
+        @"$msclkid": @"bing_click_42",
+        @"$msclkid_creation_time": @(nowMs),
+    };
+    [[FPState sharedInstance] mergeClickIds:clickId];
+
+    // Drain the barrier write by doing a sync read.
+    (void)[[FPState sharedInstance] activeClickIdsFlattened];
+
+    NSData *stored = [[NSUserDefaults standardUserDefaults] dataForKey:kFPClickIdsKey];
+    XCTAssertNotNil(stored, @"NSUserDefaults must contain data for com.freshpaint.clickIds after mergeClickIds");
+
+    // Deserialize and verify the value is present.
+    NSError *error = nil;
+    id plist = [NSPropertyListSerialization propertyListWithData:stored
+                                                         options:NSPropertyListImmutable
+                                                          format:nil
+                                                           error:&error];
+    XCTAssertNil(error, @"Persisted plist data must be valid");
+    XCTAssertTrue([plist isKindOfClass:[NSDictionary class]], @"Persisted data must be a NSDictionary");
+    XCTAssertEqualObjects(((NSDictionary *)plist)[@"$msclkid"], @"bing_click_42",
+        @"$msclkid must be persisted in NSUserDefaults");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 15: URL with no recognized params returns empty clickIds dict
+// ---------------------------------------------------------------------------
+
+- (void)testNoClickIdsInURLProducesEmptyDict
+{
+    NSURL *url = [NSURL URLWithString:@"https://example.com?foo=bar&baz=qux"];
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+
+    XCTAssertNotNil(clickIds, @"clickIds dict must be non-nil even when nothing is found");
+    XCTAssertEqual(clickIds.count, 0u, @"clickIds must be empty when no recognized params are present");
+}
+
+@end

--- a/FreshpaintTests/FPDeepLinkAttributionTests.m
+++ b/FreshpaintTests/FPDeepLinkAttributionTests.m
@@ -55,6 +55,8 @@
 static NSString *const kFPDLBuildKeyV2  = @"FPBuildKeyV2";
 static NSString *const kFPDLVersionKey  = @"FPVersionKey";
 static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
+static NSString *const kFPUTMParamsKey  = @"com.freshpaint.utmParams";
+static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
 
 // ---------------------------------------------------------------------------
 #pragma mark - Test class
@@ -68,6 +70,8 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
 @property (nonatomic, copy, nullable) NSString         *savedBuildV2;
 @property (nonatomic, copy, nullable) NSString         *savedVersion;
 @property (nonatomic, copy, nullable) NSData           *savedClickIds;
+@property (nonatomic, copy, nullable) NSData           *savedUTMParams;
+@property (nonatomic, assign)         double            savedUTMExpiry;
 @end
 
 @implementation FPDeepLinkAttributionTests
@@ -77,13 +81,17 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
     [super setUp];
 
     // Save and clear persistent state that may affect tests.
-    self.savedBuildV2  = [[NSUserDefaults standardUserDefaults] stringForKey:kFPDLBuildKeyV2];
-    self.savedVersion  = [[NSUserDefaults standardUserDefaults] stringForKey:kFPDLVersionKey];
-    self.savedClickIds = [[NSUserDefaults standardUserDefaults] dataForKey:kFPClickIdsKey];
+    self.savedBuildV2   = [[NSUserDefaults standardUserDefaults] stringForKey:kFPDLBuildKeyV2];
+    self.savedVersion   = [[NSUserDefaults standardUserDefaults] stringForKey:kFPDLVersionKey];
+    self.savedClickIds  = [[NSUserDefaults standardUserDefaults] dataForKey:kFPClickIdsKey];
+    self.savedUTMParams = [[NSUserDefaults standardUserDefaults] dataForKey:kFPUTMParamsKey];
+    self.savedUTMExpiry = [[NSUserDefaults standardUserDefaults] doubleForKey:kFPUTMExpiryKey];
 
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPDLBuildKeyV2];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPDLVersionKey];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPClickIdsKey];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPUTMParamsKey];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPUTMExpiryKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
 
     // Also clear in-memory state on the shared FPState singleton.
@@ -119,6 +127,13 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
         [[NSUserDefaults standardUserDefaults] setObject:self.savedClickIds forKey:kFPClickIdsKey];
     } else {
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPClickIdsKey];
+    }
+    if (self.savedUTMParams) {
+        [[NSUserDefaults standardUserDefaults] setObject:self.savedUTMParams forKey:kFPUTMParamsKey];
+        [[NSUserDefaults standardUserDefaults] setDouble:self.savedUTMExpiry forKey:kFPUTMExpiryKey];
+    } else {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPUTMParamsKey];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPUTMExpiryKey];
     }
     [[NSUserDefaults standardUserDefaults] synchronize];
 
@@ -220,10 +235,10 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
     XCTAssertNotNil(creationTime, @"$gclid_creation_time must be present");
     XCTAssertTrue([creationTime isKindOfClass:[NSNumber class]],
                   @"$gclid_creation_time must be an NSNumber");
-    NSInteger ms = [creationTime integerValue];
-    XCTAssertGreaterThan(ms, 0, @"$gclid_creation_time must be a positive Unix timestamp in ms");
+    int64_t ms = [creationTime longLongValue];
+    XCTAssertGreaterThan(ms, (int64_t)0, @"$gclid_creation_time must be a positive Unix timestamp in ms");
     // Sanity: should be at least year-2020 epoch ms.
-    XCTAssertGreaterThan(ms, (NSInteger)1577836800000LL,
+    XCTAssertGreaterThan(ms, (int64_t)1577836800000LL,
                          @"$gclid_creation_time should be a plausible recent Unix ms timestamp");
 }
 
@@ -264,7 +279,7 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
 - (void)testDeduplicationSameValue
 {
     // Seed an initial click ID with a known creation_time.
-    NSInteger oldTimeMs = 1000000000000LL; // past timestamp
+    int64_t oldTimeMs = 1000000000000LL; // past timestamp
     NSDictionary *initial = @{
         @"$gclid": @"same_value",
         @"$gclid_creation_time": @(oldTimeMs),
@@ -278,7 +293,7 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
     XCTAssertEqualObjects(afterFirst[@"$gclid_creation_time"], @(oldTimeMs));
 
     // Now merge the same key with the same value but a newer creation_time.
-    NSInteger newTimeMs = oldTimeMs + 1000;
+    int64_t newTimeMs = oldTimeMs + 1000;
     NSDictionary *duplicate = @{
         @"$gclid": @"same_value",
         @"$gclid_creation_time": @(newTimeMs),
@@ -352,7 +367,7 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
     // Pre-store a click ID so it is available when app_install fires.
     NSDictionary *clickId = @{
         @"$gclid": @"install_gclid",
-        @"$gclid_creation_time": @((NSInteger)([[NSDate date] timeIntervalSince1970] * 1000)),
+        @"$gclid_creation_time": @((int64_t)([[NSDate date] timeIntervalSince1970] * 1000)),
     };
     [[FPState sharedInstance] mergeClickIds:clickId];
 
@@ -442,7 +457,7 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
 
 - (void)testClickIdsPersistAfterMerge
 {
-    NSInteger nowMs = (NSInteger)([[NSDate date] timeIntervalSince1970] * 1000);
+    int64_t nowMs = (int64_t)([[NSDate date] timeIntervalSince1970] * 1000);
     NSDictionary *clickId = @{
         @"$msclkid": @"bing_click_42",
         @"$msclkid_creation_time": @(nowMs),
@@ -479,6 +494,108 @@ static NSString *const kFPClickIdsKey   = @"com.freshpaint.clickIds";
 
     XCTAssertNotNil(clickIds, @"clickIds dict must be non-nil even when nothing is found");
     XCTAssertEqual(clickIds.count, 0u, @"clickIds must be empty when no recognized params are present");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 16: continueUserActivity: extracts click IDs from universal link
+// ---------------------------------------------------------------------------
+
+- (void)testContinueUserActivityExtractsAttribution
+{
+    NSURL *url = [NSURL URLWithString:@"https://example.com/promo?gclid=universal_gclid123"];
+
+    NSUserActivity *activity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+    activity.webpageURL = url;
+
+    [self.analytics continueUserActivity:activity];
+
+    // Drain the barrier write by doing a sync read.
+    NSDictionary *stored = [[FPState sharedInstance] activeClickIdsFlattened];
+    XCTAssertEqualObjects(stored[@"$gclid"], @"universal_gclid123",
+        @"$gclid must be extracted and stored when received via continueUserActivity:");
+    XCTAssertTrue([self capturedEventNamed:@"Deep Link Opened"],
+        @"Deep Link Opened must fire for universal links via continueUserActivity:");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 17: _applicationDidFinishLaunchingWithOptions with launch URL
+// ---------------------------------------------------------------------------
+
+- (void)testLaunchURLExtractionInDidFinishLaunching
+{
+#if TARGET_OS_IOS
+    NSURL *launchURL = [NSURL URLWithString:@"myapp://open?ttclid=tiktok_launch_99&utm_source=tiktok"];
+    NSDictionary *launchOptions = @{ UIApplicationLaunchOptionsURLKey: launchURL };
+
+    [self.analytics _applicationDidFinishLaunchingWithOptions:launchOptions];
+
+    FPTrackPayload *install = [self firstCapturedEventNamed:@"app_install"];
+    XCTAssertNotNil(install, @"app_install must fire on fresh launch with URL");
+    XCTAssertEqualObjects(install.properties[@"$ttclid"], @"tiktok_launch_99",
+        @"$ttclid from the launch URL must be merged into app_install payload");
+    XCTAssertEqualObjects(install.properties[@"utm_source"], @"tiktok",
+        @"utm_source from the launch URL must be merged into app_install payload");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 18: UTM params persist to NSUserDefaults across app kills
+// ---------------------------------------------------------------------------
+
+- (void)testUTMParamsPersistToUserDefaults
+{
+    NSDictionary *params = @{ @"utm_source": @"google", @"utm_medium": @"cpc" };
+    [[FPState sharedInstance] setUTMParams:params];
+
+    // Drain the barrier write.
+    (void)[[FPState sharedInstance] activeUTMParams];
+
+    NSData *stored = [[NSUserDefaults standardUserDefaults] dataForKey:kFPUTMParamsKey];
+    XCTAssertNotNil(stored, @"UTM params must be written to NSUserDefaults so they survive app kills");
+
+    double expiry = [[NSUserDefaults standardUserDefaults] doubleForKey:kFPUTMExpiryKey];
+    XCTAssertGreaterThan(expiry, [[NSDate date] timeIntervalSince1970],
+        @"UTM expiry timestamp must be in the future after setUTMParams:");
+
+    NSError *error = nil;
+    id plist = [NSPropertyListSerialization propertyListWithData:stored
+                                                         options:NSPropertyListImmutable
+                                                          format:nil
+                                                           error:&error];
+    XCTAssertNil(error, @"Persisted UTM plist must be valid");
+    XCTAssertEqualObjects(((NSDictionary *)plist)[@"utm_source"], @"google",
+        @"utm_source must be present in persisted UTM data");
+}
+
+// ---------------------------------------------------------------------------
+#pragma mark - Test 19: Nil URL and URL with no query string are safe (negative cases)
+// ---------------------------------------------------------------------------
+
+- (void)testNilURLProducesEmptyDicts
+{
+    NSDictionary *result = [FPAdClickIds extractFromURL:nil payloadFilters:@{}];
+    XCTAssertNotNil(result[@"clickIds"],  @"clickIds key must be present even for nil URL");
+    XCTAssertNotNil(result[@"utmParams"], @"utmParams key must be present even for nil URL");
+    XCTAssertEqual([result[@"clickIds"] count],  (NSUInteger)0, @"clickIds must be empty for nil URL");
+    XCTAssertEqual([result[@"utmParams"] count], (NSUInteger)0, @"utmParams must be empty for nil URL");
+}
+
+- (void)testURLWithNoQueryStringProducesEmptyDicts
+{
+    NSURL *url = [NSURL URLWithString:@"https://example.com/landing"];
+    NSDictionary *result = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    XCTAssertEqual([result[@"clickIds"] count],  (NSUInteger)0, @"clickIds must be empty for URL with no query");
+    XCTAssertEqual([result[@"utmParams"] count], (NSUInteger)0, @"utmParams must be empty for URL with no query");
+}
+
+- (void)testPercentEncodedParamValueExtracted
+{
+    // Percent-encoded click ID value — NSURL decodes it automatically.
+    NSURL *url = [NSURL URLWithString:@"https://example.com?gclid=hello%20world%21"];
+    NSDictionary *result   = [FPAdClickIds extractFromURL:url payloadFilters:@{}];
+    NSDictionary *clickIds = result[@"clickIds"];
+    XCTAssertEqualObjects(clickIds[@"$gclid"], @"hello world!",
+        @"Percent-encoded click ID values must be decoded by NSURL before extraction");
 }
 
 @end

--- a/FreshpaintTests/FPDeepLinkAttributionTests.m
+++ b/FreshpaintTests/FPDeepLinkAttributionTests.m
@@ -192,7 +192,9 @@ static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
 
     // Each canonical key should appear prefixed with $ in the result.
     // Note: sccid and ScCid both map to lowercase "sccid", so only one will win (first match).
-    // We check that at least 23 unique canonical keys got extracted (sccid and ScCid de-dup to 1).
+    // sccid and ScCid share the same lowercase form; ScCid is the canonical key (it is
+    // listed last in supportedClickIdKeys so it overwrites sccid in lowercaseToCanonical).
+    // Exactly 23 distinct prefixed keys are expected: 22 non-Snapchat + $ScCid.
     NSUInteger foundCount = 0;
     for (NSString *key in supported) {
         NSString *prefixed = [NSString stringWithFormat:@"$%@", key];
@@ -200,9 +202,11 @@ static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
             foundCount++;
         }
     }
-    // At minimum 23 distinct canonical entries (sccid/ScCid de-dup to one).
-    XCTAssertGreaterThanOrEqual(foundCount, 23u,
-        @"At least 23 out of 24 entries should be extracted (sccid/ScCid are case-insensitive duplicates)");
+    XCTAssertEqual(foundCount, 23u,
+        @"Exactly 23 entries should be extracted (sccid/ScCid de-dup to $ScCid)");
+    // The canonical Snapchat key must be $ScCid, not $sccid.
+    XCTAssertNotNil(clickIds[@"$ScCid"], @"$ScCid must be present as the canonical Snapchat key");
+    XCTAssertNil(clickIds[@"$sccid"], @"$sccid must not appear — $ScCid is the canonical form");
 }
 
 // ---------------------------------------------------------------------------
@@ -445,10 +449,13 @@ static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
         @"Extraction with both sccid and ScCid variants must not throw");
 
     NSDictionary *clickIds = result[@"clickIds"];
-    // At least one of the two canonical forms must be present.
-    BOOL eitherFound = (clickIds[@"$sccid"] != nil || clickIds[@"$ScCid"] != nil);
-    XCTAssertTrue(eitherFound,
-        @"At least one of $sccid or $ScCid must be present in the result");
+    // $ScCid is always the canonical key: ScCid is listed after sccid in supportedClickIdKeys,
+    // so it wins the lowercaseToCanonical slot. sccid appears first in the URL, so its value
+    // (snap1) is stored under $ScCid. $sccid must not exist.
+    XCTAssertEqualObjects(clickIds[@"$ScCid"], @"snap1",
+        @"$ScCid must hold the value from the first URL match (sccid=snap1)");
+    XCTAssertNil(clickIds[@"$sccid"],
+        @"$sccid must not be present — $ScCid is the only canonical Snapchat key");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **FRP-37**: Rename `Application Installed` to `app_install` with full MMP attribution payload, fix double-write of version keys on fresh install
- **FRP-38**: Deep link attribution — ad click IDs (gclid, fbclid, etc.) and UTM parameter extraction from launch URLs
- **FRP-39**: Apple Ads attribution token retrieval and SKAdNetwork conversion value support
- **FRP-59**: Review feedback refinements for `app_install` event and ATT handling
- **FRP-61**: Cache `lowercaseToCanonical` map with `dispatch_once`, fix FPAdClickIds header visibility

This single PR consolidates all remaining MMP feature branches (FRP-37, FRP-38, FRP-39, FRP-59, FRP-61) into `mmp-integrations`. These branches were stacked via PRs #30, #32, #33, #35, and #37, all converging into `feature/frp-37-app-install-mmp-payload`.

## Test plan

- [ ] Verify `app_install` event fires with full MMP attribution payload on fresh install
- [ ] Verify deep link opens populate ad click IDs and UTM params in `Application Opened`
- [ ] Verify Apple Ads attribution token is fetched and included when available
- [ ] Verify SKAdNetwork conversion value updates work on supported OS versions
- [ ] Run full test suite (`pod lib lint` or Xcode tests)