### PR TITLE
feat(ios): replace Keychain with NSUserDefaults for persistent_device_id [FRP-76]

### DIFF
--- a/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
@@ -33,6 +33,7 @@ struct AttributionDemoView: View {
     @State private var idfa: String = "Not available"
     @State private var idfv: String = "Not available"
     @State private var stableDeviceId: String = "Not available"
+    @State private var persistentDeviceId: String = "Not available"
     @State private var appVersion: String = "Not available"
     @State private var isFirstLaunch: Bool = false
 
@@ -84,6 +85,7 @@ struct AttributionDemoView: View {
         CardView(title: "Device Identifiers") {
             VStack(spacing: 12) {
                 AttributionRow(label: "Device ID", value: stableDeviceId)
+                AttributionRow(label: "Persistent ID", value: persistentDeviceId)
                 AttributionRow(label: "IDFV", value: idfv)
                 AttributionRow(label: "IDFA", value: idfa)
                 AttributionRow(label: "ATT Status", value: attStatusString(attStatus))
@@ -206,8 +208,9 @@ struct AttributionDemoView: View {
             ("fp_click_id",   lastFpClickId == "null"    ? .null : .string(lastFpClickId)),
             ("utm_source",    lastUtmSource == "null"    ? .null : .string(lastUtmSource)),
             ("utm_campaign",  lastUtmCampaign == "null"  ? .null : .string(lastUtmCampaign)),
-            ("device_id",     .string(stableDeviceId)),
-            ("first_launch",  .bool(isFirstLaunch)),
+            ("device_id",              .string(stableDeviceId)),
+            ("persistent_device_id",   .string(persistentDeviceId)),
+            ("first_launch",           .bool(isFirstLaunch)),
         ]
     }
 
@@ -216,6 +219,7 @@ struct AttributionDemoView: View {
     private func refresh() {
         attStatus = Freshpaint.trackingAuthorizationStatus()
         stableDeviceId = "Auto-enriched in event context"
+        persistentDeviceId = Freshpaint.stableDeviceId()
         idfv = UIDevice.current.identifierForVendor?.uuidString ?? "Not available"
         idfa = Freshpaint.advertisingIdentifier() ?? "Not available"
         appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"

--- a/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/AttributionDemoView.swift
@@ -32,7 +32,7 @@ struct AttributionDemoView: View {
     @State private var attStatus: UInt = 0
     @State private var idfa: String = "Not available"
     @State private var idfv: String = "Not available"
-    @State private var stableDeviceId: String = "Not available"
+    @State private var deviceId: String = "Not available"
     @State private var persistentDeviceId: String = "Not available"
     @State private var appVersion: String = "Not available"
     @State private var isFirstLaunch: Bool = false
@@ -84,7 +84,7 @@ struct AttributionDemoView: View {
     private var deviceIdentifiersCard: some View {
         CardView(title: "Device Identifiers") {
             VStack(spacing: 12) {
-                AttributionRow(label: "Device ID", value: stableDeviceId)
+                AttributionRow(label: "Device ID", value: deviceId)
                 AttributionRow(label: "Persistent ID", value: persistentDeviceId)
                 AttributionRow(label: "IDFV", value: idfv)
                 AttributionRow(label: "IDFA", value: idfa)
@@ -208,9 +208,9 @@ struct AttributionDemoView: View {
             ("fp_click_id",   lastFpClickId == "null"    ? .null : .string(lastFpClickId)),
             ("utm_source",    lastUtmSource == "null"    ? .null : .string(lastUtmSource)),
             ("utm_campaign",  lastUtmCampaign == "null"  ? .null : .string(lastUtmCampaign)),
-            ("device_id",              .string(stableDeviceId)),
-            ("persistent_device_id",   .string(persistentDeviceId)),
-            ("first_launch",           .bool(isFirstLaunch)),
+            ("device_id",            .string(deviceId)),
+            ("persistent_device_id", .string(persistentDeviceId)),
+            ("first_launch",         .bool(isFirstLaunch)),
         ]
     }
 
@@ -218,8 +218,8 @@ struct AttributionDemoView: View {
 
     private func refresh() {
         attStatus = Freshpaint.trackingAuthorizationStatus()
-        stableDeviceId = "Auto-enriched in event context"
-        persistentDeviceId = Freshpaint.stableDeviceId()
+        deviceId = Freshpaint.shared().getAnonymousId()
+        persistentDeviceId = Freshpaint.shared().getPersistentDeviceId()
         idfv = UIDevice.current.identifierForVendor?.uuidString ?? "Not available"
         idfa = Freshpaint.advertisingIdentifier() ?? "Not available"
         appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"

--- a/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @State private var tapCount = 0
     @State private var isUserIdentified = false
     @State private var currentUserId: String? = nil
+    @State private var anonymousId: String = Freshpaint.shared().getAnonymousId()
     @State private var selectedTab = 0
     @State private var debugLogs: [String] = []
     @State private var showingDebugView = false
@@ -132,7 +133,7 @@ struct ContentView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                     } else {
-                        Text("Anonymous ID: \(getAnonymousId())")
+                        Text("Anonymous ID: \(anonymousId)")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -296,6 +297,7 @@ struct ContentView: View {
             Freshpaint.shared().identify(userId, traits: traits)
             currentUserId = userId
             isUserIdentified = true
+            anonymousId = Freshpaint.shared().getAnonymousId()
             addDebugLog("👤 User Identified: \(userId)")
             addDebugLog("Traits: \(traits)")
         } else {
@@ -365,15 +367,16 @@ struct ContentView: View {
     
     private func resetSession() {
         Freshpaint.shared().reset()
-        
+
         // Reset local state
         isUserIdentified = false
         currentUserId = nil
         tapCount = 0
-        
+        anonymousId = Freshpaint.shared().getAnonymousId()
+
         addDebugLog("🔄 Session Reset - All user data cleared")
         addDebugLog("User is now anonymous again with new anonymous ID")
-        addDebugLog("New Anonymous ID: \(getAnonymousId())")
+        addDebugLog("New Anonymous ID: \(anonymousId)")
     }
     
     private func trackScreenView(_ screenName: String) {
@@ -388,10 +391,6 @@ struct ContentView: View {
     }
     
     // MARK: - Helper Functions
-    
-    private func getAnonymousId() -> String {
-        return Freshpaint.shared().getAnonymousId()
-    }
     
     private func addDebugLog(_ message: String) {
         let timestamp = DateFormatter().string(from: Date())

--- a/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
@@ -317,13 +317,12 @@ struct ContentView: View {
     private func aliasUser() {
         tapCount += 1
         let newUserId = "aliased_user_\(UUID().uuidString.prefix(8))"
-        
-        Freshpaint.shared().alias(newUserId)
-        
-        // Update our local state
+
         let oldUserId = currentUserId ?? "anonymous"
+        Freshpaint.shared().alias(newUserId)
         currentUserId = newUserId
-        
+        isUserIdentified = true
+
         addDebugLog("🔗 User Aliased: \(oldUserId) → \(newUserId)")
         addDebugLog("This links the previous anonymous/identified activity to the new user ID")
     }

--- a/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
+++ b/Examples/FreshpaintDemo/FreshpaintDemo/ContentView.swift
@@ -322,6 +322,7 @@ struct ContentView: View {
         Freshpaint.shared().alias(newUserId)
         currentUserId = newUserId
         isUserIdentified = true
+        anonymousId = Freshpaint.shared().getAnonymousId()
 
         addDebugLog("🔗 User Aliased: \(oldUserId) → \(newUserId)")
         addDebugLog("This links the previous anonymous/identified activity to the new user ID")

--- a/Freshpaint/Classes/FPAnalytics.h
+++ b/Freshpaint/Classes/FPAnalytics.h
@@ -254,9 +254,9 @@ NS_SWIFT_NAME(Freshpaint)
 + (nullable NSString *)advertisingIdentifier;
 
 /**
- * Returns the stable device identifier that persists across app reinstalls via Keychain.
- * Falls back to IDFV when Keychain operations fail.
- * This is the value attached as `device_id` in every event's device context.
+ * Returns the stable device identifier backed by NSUserDefaults (key: io.freshpaint.persistentDeviceId).
+ * This is the value attached as `persistent_device_id` in every event's device context.
+ * Stable for the lifetime of the app installation; resets on uninstall.
  */
 + (NSString *)stableDeviceId;
 

--- a/Freshpaint/Classes/FPAnalytics.h
+++ b/Freshpaint/Classes/FPAnalytics.h
@@ -215,6 +215,9 @@ NS_SWIFT_NAME(Freshpaint)
 /** Returns the anonymous ID of the current user. */
 - (NSString *)getAnonymousId;
 
+/** Returns the stable persistent device ID (backed by NSUserDefaults). */
+- (NSString *)getPersistentDeviceId;
+
 /** Returns the registered device token of this device */
 - (NSString *)getDeviceToken;
 

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -223,9 +223,10 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         NSString *attStatusStr = FPATTStatusToString(attStatus);
 
         NSMutableDictionary *installProps = [NSMutableDictionary dictionary];
-        installProps[@"install_timestamp"]  = iso8601FormattedString([NSDate date]);
-        installProps[@"device_id"]          = [FPStableDeviceId deviceId];
-        installProps[@"distinct_id"]        = [self getAnonymousId] ?: @"";
+        installProps[@"install_timestamp"]    = iso8601FormattedString([NSDate date]);
+        installProps[@"device_id"]            = [self getAnonymousId];
+        installProps[@"persistent_device_id"] = [FPStableDeviceId deviceId];
+        installProps[@"distinct_id"]          = [self getAnonymousId] ?: @"";
         installProps[@"idfv"]               = [[[UIDevice currentDevice] identifierForVendor] UUIDString] ?: @"";
         installProps[@"att_status"]         = attStatusStr;
         installProps[@"limit_ad_tracking"]  = @(attStatus != kFPATTStatusAuthorized);
@@ -324,10 +325,11 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
         // Non-iOS platforms (macOS): include the fields available without iOS APIs.
         // idfv, att_status, and idfa require UIDevice/ATT and are intentionally omitted.
         [self track:@"app_install" properties:@{
-            @"install_timestamp" : iso8601FormattedString([NSDate date]),
-            @"device_id"         : [FPStableDeviceId deviceId],
-            @"os_version"        : [NSProcessInfo processInfo].operatingSystemVersionString ?: @"",
-            @"app_version"       : currentVersion ?: @"",
+            @"install_timestamp"    : iso8601FormattedString([NSDate date]),
+            @"device_id"            : [self getAnonymousId],
+            @"persistent_device_id" : [FPStableDeviceId deviceId],
+            @"os_version"           : [NSProcessInfo processInfo].operatingSystemVersionString ?: @"",
+            @"app_version"          : currentVersion ?: @"",
         }];
 #endif
     } else {

--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -665,6 +665,11 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     return [FPState sharedInstance].userInfo.anonymousId;
 }
 
+- (NSString *)getPersistentDeviceId
+{
+    return [FPStableDeviceId deviceId];
+}
+
 - (NSString *)getDeviceToken
 {
     return [FPState sharedInstance].context.deviceToken;

--- a/Freshpaint/Classes/FPAttributionMiddleware.m
+++ b/Freshpaint/Classes/FPAttributionMiddleware.m
@@ -52,7 +52,8 @@ static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000"
         NSUInteger status = [self currentATTStatus];
         NSMutableDictionary *enrichment = [NSMutableDictionary dictionary];
 
-        enrichment[@"att_status"]          = FPATTStatusToString(status);
+        enrichment[@"att_status"]           = FPATTStatusToString(status);
+        enrichment[@"device_id"]            = payload.anonymousId ?: @"";
         enrichment[@"persistent_device_id"] = [FPStableDeviceId deviceId];
 
         // Include IDFA only when fully authorized and adSupportBlock is set.

--- a/Freshpaint/Classes/FPAttributionMiddleware.m
+++ b/Freshpaint/Classes/FPAttributionMiddleware.m
@@ -8,6 +8,7 @@
 #import "FPPayload.h"
 #import "FPPayload+FPAttributionEnrichment.h"
 #import "FPATTRuntime.h"
+#import "FPStableDeviceId.h"
 #import <objc/runtime.h>
 
 static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000";
@@ -51,7 +52,8 @@ static NSString *const kFPAllZerosIDFA = @"00000000-0000-0000-0000-000000000000"
         NSUInteger status = [self currentATTStatus];
         NSMutableDictionary *enrichment = [NSMutableDictionary dictionary];
 
-        enrichment[@"att_status"] = FPATTStatusToString(status);
+        enrichment[@"att_status"]          = FPATTStatusToString(status);
+        enrichment[@"persistent_device_id"] = [FPStableDeviceId deviceId];
 
         // Include IDFA only when fully authorized and adSupportBlock is set.
         if (status == kFPATTStatusAuthorized && self.configuration.adSupportBlock != nil) {

--- a/Freshpaint/Internal/FPStableDeviceId.h
+++ b/Freshpaint/Internal/FPStableDeviceId.h
@@ -8,26 +8,37 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Provides a stable device identifier that persists across app reinstalls via Keychain.
- * Falls back to IDFV if Keychain operations fail.
+ * Provides a stable device identifier backed by NSUserDefaults.
+ * The identifier is stored under the key `io.freshpaint.persistentDeviceId`.
+ * Falls back to IDFV if NSUserDefaults write fails.
+ *
+ * NOTE: Unlike Keychain storage, NSUserDefaults values do NOT survive app uninstall.
+ * The identifier is stable for the lifetime of the app installation on the device,
+ * which is the intended and accepted trade-off.
  */
 @interface FPStableDeviceId : NSObject
 
 /**
- * Returns a stable device UUID. On first call, generates a UUID and persists it to Keychain
- * (service: com.freshpaint.sdk.device_id, accessibility: kSecAttrAccessibleAfterFirstUnlock).
- * On subsequent calls, returns the cached or Keychain-persisted UUID.
- * Falls back to IDFV when Keychain write fails; retries write on the next call.
- *
- * NOTE: The Keychain item uses kSecAttrAccessibleAfterFirstUnlock, which means it is
- * unavailable until after the first device unlock following a reboot. Events fired
- * before first unlock will use the IDFV fallback.
- *
- * NOTE: Keychain items persist across app uninstall/reinstall on the same device —
- * this is intentional and is what makes device_id stable across reinstalls.
+ * Returns a stable device UUID. On first call, generates a UUID and persists it to
+ * NSUserDefaults under key `io.freshpaint.persistentDeviceId`. On subsequent calls,
+ * returns the cached or NSUserDefaults-persisted UUID.
+ * Falls back to IDFV when NSUserDefaults write fails; retries write on the next call.
  */
 + (NSString *)deviceId;
 
 @end
 
 NS_ASSUME_NONNULL_END
+
+#if DEBUG
+/**
+ * Test helpers — not for production use.
+ */
+@interface FPStableDeviceId (Testing)
++ (void)fp_resetCachedIdForTesting;
++ (void)fp_resetUserDefaultsForTesting;
++ (BOOL)fp_writeToUserDefaults:(NSString *)value;
++ (nullable NSString *)fp_readFromUserDefaults;
++ (NSString *)fp_idfvFallback;
+@end
+#endif

--- a/Freshpaint/Internal/FPStableDeviceId.h
+++ b/Freshpaint/Internal/FPStableDeviceId.h
@@ -10,7 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Provides a stable device identifier backed by NSUserDefaults.
  * The identifier is stored under the key `io.freshpaint.persistentDeviceId`.
- * Falls back to IDFV if NSUserDefaults write fails.
  *
  * NOTE: Unlike Keychain storage, NSUserDefaults values do NOT survive app uninstall.
  * The identifier is stable for the lifetime of the app installation on the device,
@@ -22,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns a stable device UUID. On first call, generates a UUID and persists it to
  * NSUserDefaults under key `io.freshpaint.persistentDeviceId`. On subsequent calls,
  * returns the cached or NSUserDefaults-persisted UUID.
- * Falls back to IDFV when NSUserDefaults write fails; retries write on the next call.
  */
 + (NSString *)deviceId;
 
@@ -35,9 +33,8 @@ NS_ASSUME_NONNULL_END
  * Test helpers — not for production use.
  */
 @interface FPStableDeviceId (Testing)
-+ (void)fp_resetCachedIdForTesting;
 + (void)fp_resetUserDefaultsForTesting;
-+ (BOOL)fp_writeToUserDefaults:(NSString *)value;
++ (void)fp_writeToUserDefaults:(NSString *)value;
 + (nullable NSString *)fp_readFromUserDefaults;
 + (NSString *)fp_idfvFallback;
 @end

--- a/Freshpaint/Internal/FPStableDeviceId.m
+++ b/Freshpaint/Internal/FPStableDeviceId.m
@@ -4,13 +4,11 @@
 //
 
 #import "FPStableDeviceId.h"
-#import <Security/Security.h>
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #endif
 
-static NSString *const kFPStableDeviceIdService = @"com.freshpaint.sdk.device_id";
-static NSString *const kFPStableDeviceIdAccount = @"device_id";
+static NSString *const kFPStableDeviceIdUserDefaultsKey = @"io.freshpaint.persistentDeviceId";
 
 // Access to this variable is serialized via fp_queue (dispatch_sync).
 static NSString *_fpCachedDeviceId = nil;
@@ -37,21 +35,18 @@ static NSString *_fpCachedDeviceId = nil;
             return;
         }
 
-        // Try to read a previously persisted UUID from Keychain.
-        NSString *stored = [self fp_readFromKeychain];
+        // Try to read a previously persisted UUID from NSUserDefaults.
+        NSString *stored = [self fp_readFromUserDefaults];
         if (stored) {
             _fpCachedDeviceId = stored;
             result = stored;
             return;
         }
 
-        // Nothing persisted — generate a new UUID and try to write it.
+        // Nothing persisted — generate a new UUID and write it.
         NSString *newId = [[NSUUID UUID] UUIDString];
-        BOOL written = [self fp_writeToKeychain:newId];
+        BOOL written = [self fp_writeToUserDefaults:newId];
         if (written) {
-            // fp_writeToKeychain may have set _fpCachedDeviceId to a
-            // pre-existing Keychain value (errSecDuplicateItem path).
-            // Only assign newId if the cache wasn't already populated.
             if (!_fpCachedDeviceId) {
                 _fpCachedDeviceId = newId;
             }
@@ -59,62 +54,25 @@ static NSString *_fpCachedDeviceId = nil;
         }
         // If write failed: result remains nil here.
         // The caller falls back to IDFV and we do NOT cache,
-        // so the next call will retry the Keychain write.
+        // so the next call will retry the write.
     });
 
     if (result) {
         return result;
     }
-    // Graceful fallback when Keychain is completely unavailable.
+    // Graceful fallback when NSUserDefaults is completely unavailable.
     return [self fp_idfvFallback];
 }
 
-+ (nullable NSString *)fp_readFromKeychain
++ (nullable NSString *)fp_readFromUserDefaults
 {
-    NSDictionary *query = @{
-        (__bridge id)kSecClass:       (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecAttrService: kFPStableDeviceIdService,
-        (__bridge id)kSecAttrAccount: kFPStableDeviceIdAccount,
-        (__bridge id)kSecReturnData:  @YES,
-        (__bridge id)kSecMatchLimit:  (__bridge id)kSecMatchLimitOne
-    };
-
-    CFTypeRef dataRef = NULL;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &dataRef);
-
-    if (status == errSecSuccess && dataRef != NULL) {
-        NSData *data = (__bridge_transfer NSData *)dataRef;
-        return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    }
-    return nil;
+    return [[NSUserDefaults standardUserDefaults] stringForKey:kFPStableDeviceIdUserDefaultsKey];
 }
 
-+ (BOOL)fp_writeToKeychain:(NSString *)value
++ (BOOL)fp_writeToUserDefaults:(NSString *)value
 {
-    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
-    NSDictionary *query = @{
-        (__bridge id)kSecClass:          (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecAttrService:    kFPStableDeviceIdService,
-        (__bridge id)kSecAttrAccount:    kFPStableDeviceIdAccount,
-        (__bridge id)kSecValueData:      data,
-        (__bridge id)kSecAttrAccessible: (__bridge id)kSecAttrAccessibleAfterFirstUnlock
-    };
-
-    OSStatus status = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
-    if (status == errSecSuccess) {
-        return YES;
-    }
-    if (status == errSecDuplicateItem) {
-        // An item already exists (e.g. restored backup, MDM-provisioned device,
-        // or a partial write from a previous launch). Read it back so the caller
-        // can populate the cache rather than falling back to IDFV permanently.
-        NSString *existing = [self fp_readFromKeychain];
-        if (existing) {
-            _fpCachedDeviceId = existing;
-        }
-        return (existing != nil);
-    }
-    return NO;
+    [[NSUserDefaults standardUserDefaults] setObject:value forKey:kFPStableDeviceIdUserDefaultsKey];
+    return YES;
 }
 
 + (NSString *)fp_idfvFallback
@@ -139,14 +97,12 @@ static NSString *_fpCachedDeviceId = nil;
     });
 }
 
-+ (void)fp_deleteKeychainItemForTesting
++ (void)fp_resetUserDefaultsForTesting
 {
-    NSDictionary *query = @{
-        (__bridge id)kSecClass:       (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecAttrService: kFPStableDeviceIdService,
-        (__bridge id)kSecAttrAccount: kFPStableDeviceIdAccount
-    };
-    SecItemDelete((__bridge CFDictionaryRef)query);
+    dispatch_sync([self fp_queue], ^{
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFPStableDeviceIdUserDefaultsKey];
+        _fpCachedDeviceId = nil;
+    });
 }
 
 #endif

--- a/Freshpaint/Internal/FPStableDeviceId.m
+++ b/Freshpaint/Internal/FPStableDeviceId.m
@@ -45,16 +45,9 @@ static NSString *_fpCachedDeviceId = nil;
 
         // Nothing persisted — generate a new UUID and write it.
         NSString *newId = [[NSUUID UUID] UUIDString];
-        BOOL written = [self fp_writeToUserDefaults:newId];
-        if (written) {
-            if (!_fpCachedDeviceId) {
-                _fpCachedDeviceId = newId;
-            }
-            result = _fpCachedDeviceId;
-        }
-        // If write failed: result remains nil here.
-        // The caller falls back to IDFV and we do NOT cache,
-        // so the next call will retry the write.
+        [self fp_writeToUserDefaults:newId];
+        _fpCachedDeviceId = newId;
+        result = newId;
     });
 
     if (result) {

--- a/Freshpaint/Internal/FPStableDeviceId.m
+++ b/Freshpaint/Internal/FPStableDeviceId.m
@@ -50,11 +50,7 @@ static NSString *_fpCachedDeviceId = nil;
         result = newId;
     });
 
-    if (result) {
-        return result;
-    }
-    // Graceful fallback when NSUserDefaults is completely unavailable.
-    return [self fp_idfvFallback];
+    return result;
 }
 
 + (nullable NSString *)fp_readFromUserDefaults
@@ -62,10 +58,9 @@ static NSString *_fpCachedDeviceId = nil;
     return [[NSUserDefaults standardUserDefaults] stringForKey:kFPStableDeviceIdUserDefaultsKey];
 }
 
-+ (BOOL)fp_writeToUserDefaults:(NSString *)value
++ (void)fp_writeToUserDefaults:(NSString *)value
 {
     [[NSUserDefaults standardUserDefaults] setObject:value forKey:kFPStableDeviceIdUserDefaultsKey];
-    return YES;
 }
 
 + (NSString *)fp_idfvFallback
@@ -82,13 +77,6 @@ static NSString *_fpCachedDeviceId = nil;
 
 #if DEBUG
 // Test helpers — not for production use.
-
-+ (void)fp_resetCachedIdForTesting
-{
-    dispatch_sync([self fp_queue], ^{
-        _fpCachedDeviceId = nil;
-    });
-}
 
 + (void)fp_resetUserDefaultsForTesting
 {

--- a/Freshpaint/Internal/FPUtils.m
+++ b/Freshpaint/Internal/FPUtils.m
@@ -7,7 +7,6 @@
 #import "FPAnalyticsConfiguration.h"
 #import "FPReachability.h"
 #import "FPAnalytics.h"
-#import "FPStableDeviceId.h"
 #import "FPState.h"
 
 #include <sys/sysctl.h>
@@ -207,7 +206,6 @@ NSDictionary *mobileSpecifications(FPAnalyticsConfiguration *configuration, NSSt
             dict[@"id"] = vendorId;
             dict[@"idfv"] = vendorId;
         }
-        dict[@"device_id"] = [FPStableDeviceId deviceId];
         if (getAdTrackingEnabled(configuration)) {
             NSString *idfa = configuration.adSupportBlock();
             // This isn't ideal.  We're doing this because we can't actually check if IDFA is enabled on

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -13,10 +13,16 @@
 #import "FPContext.h"
 #import "FPTrackPayload.h"
 #import "FPATTTestConstants.h"
+#import "FPStableDeviceId.h"
 
 // NSUserDefaults keys — defined in FPAnalytics.m, declared here for test access.
 extern NSString *const FPVersionKey;
 extern NSString *const FPBuildKeyV2;
+
+// Expose NSUserDefaults test helpers from FPStableDeviceId.
+@interface FPStableDeviceId (Testing)
++ (void)fp_resetUserDefaultsForTesting;
+@end
 
 // ---------------------------------------------------------------------------
 #pragma mark - Test-only extensions
@@ -104,6 +110,9 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPBuildKeyV2];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPVersionKey];
 
+    // Start with no persistent device ID so each test gets a fresh UUID.
+    [FPStableDeviceId fp_resetUserDefaultsForTesting];
+
     // Build a configuration that fires lifecycle events but does NOT hook into
     // UIApplication (no notifications registered — tests drive the method directly).
     self.configuration = [FPAnalyticsConfiguration configurationWithWriteKey:@"TEST_WRITE_KEY"];
@@ -130,6 +139,8 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:FPVersionKey];
     }
     [[NSUserDefaults standardUserDefaults] synchronize];
+
+    [FPStableDeviceId fp_resetUserDefaultsForTesting];
 
     self.analytics     = nil;
     self.capture       = nil;
@@ -229,11 +240,21 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     XCTAssertNotNil([df dateFromString:timestamp],
                     @"install_timestamp must be a valid ISO 8601 date string, got: %@", timestamp);
 
-    // device_id — non-empty UUID string
+    // device_id — must equal the analytics anonymousId
     NSString *deviceId = props[@"device_id"];
     XCTAssertNotNil(deviceId, @"device_id must be present");
-    XCTAssertNotNil([[NSUUID alloc] initWithUUIDString:deviceId],
-                    @"device_id must be a valid UUID, got: %@", deviceId);
+    XCTAssertEqualObjects(deviceId, [self.analytics getAnonymousId],
+                          @"device_id must equal the SDK anonymousId");
+
+    // persistent_device_id — must be present and a valid UUID
+    NSString *persistentDeviceId = props[@"persistent_device_id"];
+    XCTAssertNotNil(persistentDeviceId, @"persistent_device_id must be present");
+    XCTAssertNotNil([[NSUUID alloc] initWithUUIDString:persistentDeviceId],
+                    @"persistent_device_id must be a valid UUID, got: %@", persistentDeviceId);
+
+    // device_id and persistent_device_id must be independent values
+    XCTAssertNotEqualObjects(deviceId, persistentDeviceId,
+                             @"device_id and persistent_device_id must be different values");
 
     // idfv — non-empty string (or empty string on simulators without IDFV)
     XCTAssertNotNil(props[@"idfv"], @"idfv key must be present");

--- a/FreshpaintTests/FPStableDeviceIdTests.m
+++ b/FreshpaintTests/FPStableDeviceIdTests.m
@@ -187,22 +187,19 @@
 #pragma mark - Device context dict integration
 // ---------------------------------------------------------------------------
 
-- (void)testDeviceContextContainsDeviceIdAndIdfv
+- (void)testDeviceContextContainsIdfvButNotDeviceId
 {
 #if TARGET_OS_IPHONE
-    // device_id and idfv are only populated inside mobileSpecifications(),
-    // which is itself guarded with #if TARGET_OS_IPHONE — skip on macOS.
+    // idfv and id are set in mobileSpecifications() (static context).
+    // device_id is no longer static — it is set per-event by FPAttributionMiddleware
+    // using payload.anonymousId so it reflects the current session and resets on logout.
     FPAnalyticsConfiguration *config = [FPAnalyticsConfiguration configurationWithWriteKey:@"test"];
     NSDictionary *context = getStaticContext(config, nil);
     NSDictionary *device  = context[@"device"];
 
-    XCTAssertNotNil(device[@"device_id"], @"device_id should be present in device context");
+    XCTAssertNil(device[@"device_id"],    @"device_id must not be in static context — set per-event by FPAttributionMiddleware");
     XCTAssertNotNil(device[@"idfv"],      @"idfv should be present in device context");
     XCTAssertNotNil(device[@"id"],        @"id (backward compat) should still be present");
-
-    // device_id should be a valid UUID
-    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:device[@"device_id"]];
-    XCTAssertNotNil(uuid, @"device_id should be a valid UUID, got: %@", device[@"device_id"]);
 #endif
 }
 

--- a/FreshpaintTests/FPStableDeviceIdTests.m
+++ b/FreshpaintTests/FPStableDeviceIdTests.m
@@ -11,10 +11,10 @@
 // Expose private/debug methods for testing.
 @interface FPStableDeviceId (Testing)
 + (void)fp_resetCachedIdForTesting;
-+ (void)fp_deleteKeychainItemForTesting;
++ (void)fp_resetUserDefaultsForTesting;
++ (BOOL)fp_writeToUserDefaults:(NSString *)value;
++ (nullable NSString *)fp_readFromUserDefaults;
 + (NSString *)fp_idfvFallback;
-+ (nullable NSString *)fp_readFromKeychain;
-+ (BOOL)fp_writeToKeychain:(NSString *)value;
 @end
 
 // ---------------------------------------------------------------------------
@@ -29,15 +29,13 @@
 - (void)setUp
 {
     [super setUp];
-    // Start each test with a clean slate: no cached value, no Keychain item.
-    [FPStableDeviceId fp_resetCachedIdForTesting];
-    [FPStableDeviceId fp_deleteKeychainItemForTesting];
+    // Start each test with a clean slate: no cached value, no NSUserDefaults entry.
+    [FPStableDeviceId fp_resetUserDefaultsForTesting];
 }
 
 - (void)tearDown
 {
-    [FPStableDeviceId fp_resetCachedIdForTesting];
-    [FPStableDeviceId fp_deleteKeychainItemForTesting];
+    [FPStableDeviceId fp_resetUserDefaultsForTesting];
     [super tearDown];
 }
 
@@ -101,49 +99,36 @@
                           @"deviceId should be stable across calls within the same launch");
 }
 
-- (void)testDeviceIdPersistedToKeychain
+- (void)testDeviceIdPersistedToUserDefaults
 {
-    // Verify Keychain is available in this environment before asserting.
-    NSString *probe = [[NSUUID UUID] UUIDString];
-    BOOL available  = [FPStableDeviceId fp_writeToKeychain:probe];
-    [FPStableDeviceId fp_deleteKeychainItemForTesting];
-    XCTSkipUnless(available, @"Keychain unavailable in this environment — skipping");
-
     NSString *deviceId = [FPStableDeviceId deviceId];
-    NSString *stored   = [FPStableDeviceId fp_readFromKeychain];
+    NSString *stored   = [FPStableDeviceId fp_readFromUserDefaults];
     XCTAssertEqualObjects(deviceId, stored,
-                          @"deviceId should be persisted to Keychain");
+                          @"deviceId should be persisted to NSUserDefaults");
 }
 
-- (void)testDeviceIdRestoredFromKeychainAfterCacheReset
+- (void)testDeviceIdRestoredFromUserDefaultsAfterCacheReset
 {
-    // Probe Keychain availability before asserting persistence.
-    NSString *probe = [[NSUUID UUID] UUIDString];
-    BOOL available = [FPStableDeviceId fp_writeToKeychain:probe];
-    [FPStableDeviceId fp_deleteKeychainItemForTesting];
-    XCTSkipUnless(available, @"Keychain unavailable in this environment — skipping");
-
     // Generate and persist on first call.
     NSString *first = [FPStableDeviceId deviceId];
 
     // Clear in-memory cache to simulate a new launch.
     [FPStableDeviceId fp_resetCachedIdForTesting];
 
-    // Second call should read from Keychain and return the same UUID.
+    // Second call should read from NSUserDefaults and return the same UUID.
     NSString *second = [FPStableDeviceId deviceId];
     XCTAssertEqualObjects(first, second,
-                          @"deviceId should survive a cache reset (Keychain persistence)");
+                          @"deviceId should survive a cache reset (NSUserDefaults persistence)");
 }
 
-- (void)testPreSeededKeychainValueIsReturned
+- (void)testPreSeededUserDefaultsValueIsReturned
 {
     NSString *knownId = @"DEADBEEF-0000-0000-0000-123456789ABC";
-    BOOL written = [FPStableDeviceId fp_writeToKeychain:knownId];
-    XCTSkipUnless(written, @"Keychain unavailable in this environment — skipping");
+    [FPStableDeviceId fp_writeToUserDefaults:knownId];
 
     NSString *result = [FPStableDeviceId deviceId];
     XCTAssertEqualObjects(result, knownId,
-                          @"deviceId should return a pre-seeded Keychain value");
+                          @"deviceId should return a pre-seeded NSUserDefaults value");
 }
 
 // ---------------------------------------------------------------------------
@@ -165,51 +150,41 @@
 }
 
 // ---------------------------------------------------------------------------
-#pragma mark - FPStableDeviceId — Keychain helpers
+#pragma mark - FPStableDeviceId — NSUserDefaults helpers
 // ---------------------------------------------------------------------------
 
 - (void)testWriteAndReadRoundTrip
 {
-    NSString *value   = [[NSUUID UUID] UUIDString];
-    BOOL      written = [FPStableDeviceId fp_writeToKeychain:value];
-    XCTSkipUnless(written, @"Keychain unavailable in this environment — skipping");
+    NSString *value  = [[NSUUID UUID] UUIDString];
+    BOOL      written = [FPStableDeviceId fp_writeToUserDefaults:value];
+    XCTAssertTrue(written, @"fp_writeToUserDefaults should always return YES");
 
-    NSString *read = [FPStableDeviceId fp_readFromKeychain];
+    NSString *read = [FPStableDeviceId fp_readFromUserDefaults];
     XCTAssertEqualObjects(value, read);
 }
 
-- (void)testDuplicateKeychainItemIsReadBackNotOverwritten
+- (void)testExistingUserDefaultsValueIsReturnedNotOverwritten
 {
-    // Seed an original value into Keychain.
+    // Seed an original value into NSUserDefaults.
     NSString *originalId = @"AABBCCDD-0000-0000-0000-112233445566";
-    BOOL written = [FPStableDeviceId fp_writeToKeychain:originalId];
-    XCTSkipUnless(written, @"Keychain unavailable in this environment — skipping");
+    [FPStableDeviceId fp_writeToUserDefaults:originalId];
 
-    // Simulate the errSecDuplicateItem path by calling fp_writeToKeychain with a
-    // different ID while the original is still in Keychain. The method must:
-    //   (a) detect the duplicate, (b) read back the original, (c) set the cache.
+    // Reset cache to simulate a new launch, then call deviceId.
+    // It must read and return the seeded value, not generate a new one.
     [FPStableDeviceId fp_resetCachedIdForTesting];
-    NSString *differentId = @"11111111-2222-3333-4444-555555555555";
-    BOOL result = [FPStableDeviceId fp_writeToKeychain:differentId];
-    XCTAssertTrue(result, @"fp_writeToKeychain must return YES on errSecDuplicateItem when read-back succeeds");
-
-    // The cache must now hold the original Keychain value, NOT differentId.
-    // Verify via deviceId — cache is already populated so it returns immediately.
     NSString *deviceId = [FPStableDeviceId deviceId];
     XCTAssertEqualObjects(deviceId, originalId,
-        @"On errSecDuplicateItem, cache must hold the existing Keychain value, not the new UUID");
-    XCTAssertNotEqualObjects(deviceId, differentId,
-        @"The new UUID must not overwrite the existing Keychain value");
+        @"deviceId must return the existing NSUserDefaults value, not generate a new one");
 }
 
-- (void)testReadFromEmptyKeychainReturnsNil
+- (void)testReadFromEmptyUserDefaultsReturnsNil
 {
-    NSString *result = [FPStableDeviceId fp_readFromKeychain];
-    XCTAssertNil(result, @"Reading from an empty Keychain slot should return nil");
+    NSString *result = [FPStableDeviceId fp_readFromUserDefaults];
+    XCTAssertNil(result, @"Reading from an empty NSUserDefaults slot should return nil");
 }
 
 // ---------------------------------------------------------------------------
-#pragma mark - Device context dict integration (ACs #7 and #8)
+#pragma mark - Device context dict integration
 // ---------------------------------------------------------------------------
 
 - (void)testDeviceContextContainsDeviceIdAndIdfv

--- a/FreshpaintTests/FPStableDeviceIdTests.m
+++ b/FreshpaintTests/FPStableDeviceIdTests.m
@@ -10,9 +10,8 @@
 
 // Expose private/debug methods for testing.
 @interface FPStableDeviceId (Testing)
-+ (void)fp_resetCachedIdForTesting;
 + (void)fp_resetUserDefaultsForTesting;
-+ (BOOL)fp_writeToUserDefaults:(NSString *)value;
++ (void)fp_writeToUserDefaults:(NSString *)value;
 + (nullable NSString *)fp_readFromUserDefaults;
 + (NSString *)fp_idfvFallback;
 @end
@@ -112,8 +111,10 @@
     // Generate and persist on first call.
     NSString *first = [FPStableDeviceId deviceId];
 
-    // Clear in-memory cache to simulate a new launch.
-    [FPStableDeviceId fp_resetCachedIdForTesting];
+    // Clear both cache and NSUserDefaults then re-seed only NSUserDefaults to simulate
+    // a new process launch where the in-memory cache is cold but storage has the value.
+    [FPStableDeviceId fp_resetUserDefaultsForTesting];
+    [FPStableDeviceId fp_writeToUserDefaults:first];
 
     // Second call should read from NSUserDefaults and return the same UUID.
     NSString *second = [FPStableDeviceId deviceId];
@@ -155,9 +156,8 @@
 
 - (void)testWriteAndReadRoundTrip
 {
-    NSString *value  = [[NSUUID UUID] UUIDString];
-    BOOL      written = [FPStableDeviceId fp_writeToUserDefaults:value];
-    XCTAssertTrue(written, @"fp_writeToUserDefaults should always return YES");
+    NSString *value = [[NSUUID UUID] UUIDString];
+    [FPStableDeviceId fp_writeToUserDefaults:value];
 
     NSString *read = [FPStableDeviceId fp_readFromUserDefaults];
     XCTAssertEqualObjects(value, read);
@@ -167,11 +167,9 @@
 {
     // Seed an original value into NSUserDefaults.
     NSString *originalId = @"AABBCCDD-0000-0000-0000-112233445566";
+    [FPStableDeviceId fp_resetUserDefaultsForTesting];
     [FPStableDeviceId fp_writeToUserDefaults:originalId];
 
-    // Reset cache to simulate a new launch, then call deviceId.
-    // It must read and return the seeded value, not generate a new one.
-    [FPStableDeviceId fp_resetCachedIdForTesting];
     NSString *deviceId = [FPStableDeviceId deviceId];
     XCTAssertEqualObjects(deviceId, originalId,
         @"deviceId must return the existing NSUserDefaults value, not generate a new one");
@@ -190,14 +188,14 @@
 - (void)testDeviceContextContainsIdfvButNotDeviceId
 {
 #if TARGET_OS_IPHONE
-    // idfv and id are set in mobileSpecifications() (static context).
-    // device_id is no longer static — it is set per-event by FPAttributionMiddleware
-    // using payload.anonymousId so it reflects the current session and resets on logout.
+    // idfv is populated in the static context via mobileSpecifications().
+    // device_id is NOT in the static context — it is injected per-event by
+    // FPAttributionMiddleware using the current anonymousId.
     FPAnalyticsConfiguration *config = [FPAnalyticsConfiguration configurationWithWriteKey:@"test"];
     NSDictionary *context = getStaticContext(config, nil);
     NSDictionary *device  = context[@"device"];
 
-    XCTAssertNil(device[@"device_id"],    @"device_id must not be in static context — set per-event by FPAttributionMiddleware");
+    XCTAssertNil(device[@"device_id"],    @"device_id must not be in the static context (injected per-event by middleware)");
     XCTAssertNotNil(device[@"idfv"],      @"idfv should be present in device context");
     XCTAssertNotNil(device[@"id"],        @"id (backward compat) should still be present");
 #endif


### PR DESCRIPTION
## Summary

Resolves [FRP-76](https://linear.app/foxbox/issue/FRP-76).

Replaces `SecItem*` Keychain APIs in `FPStableDeviceId` with `NSUserDefaults`, eliminating App Store review flags triggered by tracking identifier persistence via Keychain.

Aligns `device_id` and `persistent_device_id` field semantics with the React Native iOS SDK.

## What changed

### Storage backend

`FPStableDeviceId` now reads/writes via `NSUserDefaults` key `io.freshpaint.persistentDeviceId` — the same key used by `FreshpaintAttribution.mm` in the RN SDK. No `Security.framework` dependency remains.

### Field semantics

| Field | Before | After |
|---|---|---|
| `device_id` | `[FPStableDeviceId deviceId]` (Keychain UUID) | `[self getAnonymousId]` (session UUID, file-backed) |
| `persistent_device_id` | absent | `[FPStableDeviceId deviceId]` (NSUserDefaults UUID) |

**`device_id`** now mirrors the RN SDK where `device_id` is Amplitude's `options.deviceId` — a UUID stored in AsyncStorage, generated on first SDK init, resets on uninstall. The native equivalent is `anonymousId`, stored in `applicationSupport/freshpaint.anonymousId`.

**`persistent_device_id`** is a new independent field mirroring RN's `getOrCreatePersistentId()` — NSUserDefaults key `io.freshpaint.persistentDeviceId`, same backend and key across both SDKs.

Both fields reset on uninstall and are sourced from separate storage slots (different values).

### Behavior comparison

| | RN iOS | freshpaint-ios (after) |
|---|---|---|
| `device_id` storage | AsyncStorage (JS app container) | `applicationSupport/freshpaint.anonymousId` (file) |
| `persistent_device_id` storage | NSUserDefaults `io.freshpaint.persistentDeviceId` | NSUserDefaults `io.freshpaint.persistentDeviceId` |
| Survives uninstall | No | No |
| Survives relaunch | Yes | Yes |

### Scope

`persistent_device_id` is added in all three relevant locations:

- `app_install` iOS event payload (`FPAnalytics.m`)
- `app_install` macOS event payload (`FPAnalytics.m`)
- Per-event device context enrichment (`FPAttributionMiddleware.m`)

## Files changed

- `Freshpaint/Internal/FPStableDeviceId.m` — NSUserDefaults backend, removed Keychain methods, simplified write path
- `Freshpaint/Internal/FPStableDeviceId.h` — updated doc comment
- `Freshpaint/Classes/FPAnalytics.m` — `device_id` → `anonymousId`, `persistent_device_id` added (iOS + macOS paths)
- `Freshpaint/Classes/FPAttributionMiddleware.m` — `persistent_device_id` enrichment added
- `FreshpaintTests/FPStableDeviceIdTests.m` — Keychain helpers replaced with NSUserDefaults equivalents, removed `XCTSkipUnless` guards
- `FreshpaintTests/FPAppInstallEventTests.m` — asserts `device_id` equals `anonymousId`, `persistent_device_id` is a valid UUID, and both values differ