### PR TITLE
fix(ios): revert install event name and payload fields to pre-MMP values [FRP-79]

### DIFF
--- a/Freshpaint/Classes/FPAnalytics.m
+++ b/Freshpaint/Classes/FPAnalytics.m
@@ -248,7 +248,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
 - (void)_applicationDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // app_install is gated on autoTrackFirstOpen (default YES), independent of
+    // Application Installed is gated on autoTrackFirstOpen (default YES), independent of
     // trackApplicationLifecycleEvents. Application Opened/Updated require the latter.
     // Run the V1→V2 migration unconditionally so a legacy key is never stranded,
     // regardless of whether lifecycle or first-open tracking is enabled.
@@ -271,7 +271,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
 
     if (!previousBuildV2) {
-        // Fresh install — fire app_install only when autoTrackFirstOpen is enabled.
+        // Fresh install — fire Application Installed only when autoTrackFirstOpen is enabled.
         if (trackFirstOpen) {
 #if TARGET_OS_IPHONE
             // ATT status — same associated-objects pattern as _handleDidBecomeActiveForATT.
@@ -296,8 +296,8 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
             installProps[@"manufacturer"]       = @"Apple";
             installProps[@"app_name"]           = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"]
                                                   ?: [[NSBundle mainBundle] infoDictionary][@"CFBundleName"] ?: @"";
-            installProps[@"app_version"]        = currentVersion ?: @"";
-            installProps[@"app_build"]          = currentBuild ?: @"";
+            installProps[@"version"]            = currentVersion ?: @"";
+            installProps[@"build"]              = currentBuild ?: @"";
             installProps[@"bundle_id"]          = [[NSBundle mainBundle] bundleIdentifier] ?: @"";
             installProps[@"locale"]             = [[NSLocale currentLocale] localeIdentifier] ?: @"";
 
@@ -373,7 +373,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
                 FPLog(@"Apple Ads token exception (non-fatal): %@", e);
             }
 
-            [self track:@"app_install" properties:[installProps copy]];
+            [self track:@"Application Installed" properties:[installProps copy]];
 
             // SKAdNetwork conversion value registration (StoreKit — runtime-only, opt-in).
             // Only fires when skanConversionValue is in the valid range (1-63).
@@ -384,12 +384,12 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 #else
             // Non-iOS platforms (macOS): include the fields available without iOS APIs.
             // idfv, att_status, and idfa require UIDevice/ATT and are intentionally omitted.
-            [self track:@"app_install" properties:@{
+            [self track:@"Application Installed" properties:@{
                 @"install_timestamp"    : iso8601FormattedString([NSDate date]),
                 @"device_id"            : [self getAnonymousId],
                 @"persistent_device_id" : [FPStableDeviceId deviceId],
                 @"os_version"           : [NSProcessInfo processInfo].operatingSystemVersionString ?: @"",
-                @"app_version"          : currentVersion ?: @"",
+                @"version"              : currentVersion ?: @"",
             }];
 #endif
         }
@@ -408,7 +408,7 @@ NSString *const FPBuildKeyV2 = @"FPBuildKeyV2";
 
     // Persist version/build for both fresh-install and returning-user paths.
     // For fresh installs this acts as the guard flag so a subsequent cold launch
-    // after app-kill does not re-fire app_install. For returning users it keeps
+    // after app-kill does not re-fire Application Installed. For returning users it keeps
     // the stored values current for the next Application Updated comparison.
     [[NSUserDefaults standardUserDefaults] setObject:currentVersion ?: @"" forKey:FPVersionKey];
     [[NSUserDefaults standardUserDefaults] setObject:currentBuild ?: @"" forKey:FPBuildKeyV2];

--- a/FreshpaintTests/FPAppInstallEventTests.m
+++ b/FreshpaintTests/FPAppInstallEventTests.m
@@ -149,13 +149,13 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [super tearDown];
 }
 
-// Returns the first captured app_install track payload, or nil if absent.
+// Returns the first captured Application Installed track payload, or nil if absent.
 - (nullable FPTrackPayload *)capturedInstallPayload
 {
     for (FPContext *ctx in self.capture.capturedContexts) {
         FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
         if ([track isKindOfClass:[FPTrackPayload class]] &&
-            [track.event isEqualToString:@"app_install"]) {
+            [track.event isEqualToString:@"Application Installed"]) {
             return track;
         }
     }
@@ -176,17 +176,17 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 }
 
 // ---------------------------------------------------------------------------
-#pragma mark - AC 1: Event name is app_install (AC #8: fires once on first install)
+#pragma mark - AC 1: Event name is Application Installed (AC #8: fires once on first install)
 // ---------------------------------------------------------------------------
 
-/// On the very first launch (FPBuildKeyV2 absent), app_install must be tracked.
+/// On the very first launch (FPBuildKeyV2 absent), Application Installed must be tracked.
 - (void)testFiresAppInstallOnFirstLaunch
 {
 #if TARGET_OS_IOS
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
-    XCTAssertTrue([self capturedEventNamed:@"app_install"],
-                  @"app_install must fire when FPBuildKeyV2 is absent (first install)");
+    XCTAssertTrue([self capturedEventNamed:@"Application Installed"],
+                  @"Application Installed must fire when FPBuildKeyV2 is absent (first install)");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -196,7 +196,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 #pragma mark - AC 8 (returning device): fires exactly once per install
 // ---------------------------------------------------------------------------
 
-/// On a returning launch (FPBuildKeyV2 already present), app_install must NOT fire.
+/// On a returning launch (FPBuildKeyV2 already present), Application Installed must NOT fire.
 - (void)testDoesNotFireOnReturningDevice
 {
 #if TARGET_OS_IOS
@@ -206,8 +206,8 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
-    XCTAssertFalse([self capturedEventNamed:@"app_install"],
-                   @"app_install must NOT fire when FPBuildKeyV2 is already set");
+    XCTAssertFalse([self capturedEventNamed:@"Application Installed"],
+                   @"Application Installed must NOT fire when FPBuildKeyV2 is already set");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -217,8 +217,8 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 #pragma mark - AC 2/3/4/5/7: Payload field validation
 // ---------------------------------------------------------------------------
 
-/// install_timestamp, device_id, idfv, att_status, os_version, and app_version
-/// must all be present and non-empty in the app_install payload.
+/// install_timestamp, device_id, idfv, att_status, os_version, and version
+/// must all be present and non-empty in the Application Installed payload.
 - (void)testPayloadContainsRequiredFields
 {
 #if TARGET_OS_IOS
@@ -227,7 +227,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     FPTrackPayload *payload = [self capturedInstallPayload];
-    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNotNil(payload, @"Application Installed payload must be captured");
 
     NSDictionary *props = payload.properties;
 
@@ -269,8 +269,8 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     XCTAssertNotNil(osVersion, @"os_version must be present");
     XCTAssertGreaterThan(osVersion.length, 0u);
 
-    // app_version — non-nil (may be empty in test bundle)
-    XCTAssertNotNil(props[@"app_version"], @"app_version key must be present");
+    // version — non-nil (may be empty in test bundle)
+    XCTAssertNotNil(props[@"version"], @"version key must be present");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -290,7 +290,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     FPTrackPayload *payload = [self capturedInstallPayload];
-    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNotNil(payload, @"Application Installed payload must be captured");
     XCTAssertEqualObjects(payload.properties[@"idfa"], kFPValidIDFA,
                           @"idfa must be present and match when ATT is authorized");
 #else
@@ -308,7 +308,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     FPTrackPayload *payload = [self capturedInstallPayload];
-    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNotNil(payload, @"Application Installed payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when ATT status is not authorized");
 #else
@@ -326,7 +326,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     FPTrackPayload *payload = [self capturedInstallPayload];
-    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNotNil(payload, @"Application Installed payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when adSupportBlock is nil even if ATT is authorized");
 #else
@@ -344,7 +344,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     FPTrackPayload *payload = [self capturedInstallPayload];
-    XCTAssertNotNil(payload, @"app_install payload must be captured");
+    XCTAssertNotNil(payload, @"Application Installed payload must be captured");
     XCTAssertNil(payload.properties[@"idfa"],
                  @"idfa must be absent when adSupportBlock returns all-zeros IDFA");
 #else
@@ -356,7 +356,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 #pragma mark - AC 9: Flag set after enqueue, not after flush
 // ---------------------------------------------------------------------------
 
-/// FPBuildKeyV2 must be written synchronously after the app_install event is
+/// FPBuildKeyV2 must be written synchronously after the Application Installed event is
 /// enqueued — without waiting for a flush call.
 - (void)testFlagSetAfterEnqueue
 {
@@ -370,7 +370,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     // No flush called — flag must already be set.
     NSString *storedBuild = [[NSUserDefaults standardUserDefaults] stringForKey:FPBuildKeyV2];
     XCTAssertNotNil(storedBuild,
-                    @"FPBuildKeyV2 must be written immediately after app_install is enqueued, not deferred to flush");
+                    @"FPBuildKeyV2 must be written immediately after Application Installed is enqueued, not deferred to flush");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -392,13 +392,13 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 
     // Application Updated should fire (different build stored vs. current).
     // We can't guarantee a build mismatch in the test bundle, so we just verify
-    // Application Opened always fires and app_install does NOT.
-    XCTAssertFalse([self capturedEventNamed:@"app_install"],
-                   @"app_install must not fire on a returning launch");
+    // Application Opened always fires and Application Installed does NOT on a returning launch.
+    XCTAssertFalse([self capturedEventNamed:@"Application Installed"],
+                   @"Application Installed must not fire on a returning launch");
     XCTAssertTrue([self capturedEventNamed:@"Application Opened"],
                   @"Application Opened must still fire on every launch");
-    XCTAssertFalse([self capturedEventNamed:@"Application Installed"],
-                   @"The old Application Installed event name must never fire");
+    XCTAssertFalse([self capturedEventNamed:@"app_install"],
+                   @"app_install must never fire — event name is Application Installed");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -408,7 +408,7 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
 #pragma mark - autoTrackFirstOpen independent of trackApplicationLifecycleEvents
 // ---------------------------------------------------------------------------
 
-/// app_install must fire even when trackApplicationLifecycleEvents is NO,
+/// Application Installed must fire even when trackApplicationLifecycleEvents is NO,
 /// as long as autoTrackFirstOpen is YES (the default). This is the primary
 /// production path: clients who only want MMP attribution need not opt into
 /// the full lifecycle event suite.
@@ -434,15 +434,48 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     for (FPContext *ctx in localCapture.capturedContexts) {
         FPTrackPayload *t = (FPTrackPayload *)ctx.payload;
         if (![t isKindOfClass:[FPTrackPayload class]]) continue;
-        if ([t.event isEqualToString:@"app_install"])       foundInstall = YES;
-        if ([t.event isEqualToString:@"Application Opened"]) foundOpened  = YES;
+        if ([t.event isEqualToString:@"Application Installed"]) foundInstall = YES;
+        if ([t.event isEqualToString:@"Application Opened"])    foundOpened  = YES;
     }
 
     XCTAssertTrue(foundInstall,
-                  @"app_install must fire when autoTrackFirstOpen is YES even if "
+                  @"Application Installed must fire when autoTrackFirstOpen is YES even if "
                   @"trackApplicationLifecycleEvents is NO");
     XCTAssertFalse(foundOpened,
                    @"Application Opened must NOT fire when trackApplicationLifecycleEvents is NO");
+#else
+    XCTSkip(@"This test requires iOS");
+#endif
+}
+
+/// When autoTrackFirstOpen is explicitly set to NO, Application Installed must not fire
+/// even on a fresh install.
+- (void)testAppInstallDoesNotFireWhenAutoTrackFirstOpenDisabled
+{
+#if TARGET_OS_IOS
+    FPAnalyticsConfiguration *cfg = [FPAnalyticsConfiguration configurationWithWriteKey:@"TEST_WRITE_KEY"];
+    cfg.trackApplicationLifecycleEvents = NO;
+    cfg.autoTrackFirstOpen = NO;
+    cfg.application = nil;
+
+    FPInstallEventCapture *localCapture = [[FPInstallEventCapture alloc] init];
+    cfg.sourceMiddleware = @[ localCapture ];
+
+    FPAnalytics *analytics = [[FPAnalytics alloc] initWithConfiguration:cfg];
+
+    [analytics _applicationDidFinishLaunchingWithOptions:nil];
+
+    BOOL foundInstall = NO;
+    for (FPContext *ctx in localCapture.capturedContexts) {
+        FPTrackPayload *t = (FPTrackPayload *)ctx.payload;
+        if ([t isKindOfClass:[FPTrackPayload class]] &&
+            [t.event isEqualToString:@"Application Installed"]) {
+            foundInstall = YES;
+        }
+    }
+
+    XCTAssertFalse(foundInstall,
+                   @"Application Installed must NOT fire when autoTrackFirstOpen is explicitly NO");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -466,8 +499,8 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
                                                                object:nil];
     [self.analytics fp_handleDelayedLaunch:sceneNote];
 
-    XCTAssertTrue([self capturedEventNamed:@"app_install"],
-                  @"app_install must fire when fp_handleDelayedLaunch: is called after "
+    XCTAssertTrue([self capturedEventNamed:@"Application Installed"],
+                  @"Application Installed must fire when fp_handleDelayedLaunch: is called after "
                   @"a nil-application init (iOS 26 SwiftUI path)");
 
     // Call the handler a second time to verify launchHandlerFired prevents double-firing.
@@ -477,46 +510,13 @@ static NSString *const kFPZeroIDFA   = @"00000000-0000-0000-0000-000000000000";
     for (FPContext *ctx in self.capture.capturedContexts) {
         FPTrackPayload *t = (FPTrackPayload *)ctx.payload;
         if ([t isKindOfClass:[FPTrackPayload class]] &&
-            [t.event isEqualToString:@"app_install"]) {
+            [t.event isEqualToString:@"Application Installed"]) {
             installCount++;
         }
     }
     XCTAssertEqual(installCount, 1u,
-                   @"app_install must fire exactly once — launchHandlerFired must "
+                   @"Application Installed must fire exactly once — launchHandlerFired must "
                    @"prevent a second fire on repeated handler invocations");
-#else
-    XCTSkip(@"This test requires iOS");
-#endif
-}
-
-/// When autoTrackFirstOpen is explicitly set to NO, app_install must not fire
-/// even on a fresh install.
-- (void)testAppInstallDoesNotFireWhenAutoTrackFirstOpenDisabled
-{
-#if TARGET_OS_IOS
-    FPAnalyticsConfiguration *cfg = [FPAnalyticsConfiguration configurationWithWriteKey:@"TEST_WRITE_KEY"];
-    cfg.trackApplicationLifecycleEvents = NO;
-    cfg.autoTrackFirstOpen = NO;
-    cfg.application = nil;
-
-    FPInstallEventCapture *localCapture = [[FPInstallEventCapture alloc] init];
-    cfg.sourceMiddleware = @[ localCapture ];
-
-    FPAnalytics *analytics = [[FPAnalytics alloc] initWithConfiguration:cfg];
-
-    [analytics _applicationDidFinishLaunchingWithOptions:nil];
-
-    BOOL foundInstall = NO;
-    for (FPContext *ctx in localCapture.capturedContexts) {
-        FPTrackPayload *t = (FPTrackPayload *)ctx.payload;
-        if ([t isKindOfClass:[FPTrackPayload class]] &&
-            [t.event isEqualToString:@"app_install"]) {
-            foundInstall = YES;
-        }
-    }
-
-    XCTAssertFalse(foundInstall,
-                   @"app_install must NOT fire when autoTrackFirstOpen is explicitly NO");
 #else
     XCTSkip(@"This test requires iOS");
 #endif

--- a/FreshpaintTests/FPAppleAdsAttributionTests.m
+++ b/FreshpaintTests/FPAppleAdsAttributionTests.m
@@ -157,7 +157,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     for (FPContext *ctx in self.capture.capturedContexts) {
         FPTrackPayload *track = (FPTrackPayload *)ctx.payload;
         if ([track isKindOfClass:[FPTrackPayload class]] &&
-            [track.event isEqualToString:@"app_install"]) {
+            [track.event isEqualToString:@"Application Installed"]) {
             return track;
         }
     }
@@ -180,7 +180,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 #pragma mark - AC-1, AC-2: Token capture and inclusion in payload
 // ---------------------------------------------------------------------------
 
-/// Apple Ads token returned by provider → included as apple_ads_token in app_install payload.
+/// Apple Ads token returned by provider → included as apple_ads_token in Application Installed payload.
 - (void)testAppleAdsTokenIncludedInPayload
 {
 #if TARGET_OS_IPHONE
@@ -190,7 +190,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
     FPTrackPayload *install = [self capturedInstallPayload];
-    XCTAssertNotNil(install, @"app_install event must be tracked on fresh install");
+    XCTAssertNotNil(install, @"Application Installed event must be tracked on fresh install");
     XCTAssertEqualObjects(install.properties[@"apple_ads_token"], kTestToken,
         @"apple_ads_token must be set to the value returned by attributionToken:");
 #endif
@@ -217,7 +217,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
     );
 
     FPTrackPayload *install = [self capturedInstallPayload];
-    XCTAssertNotNil(install, @"app_install must still fire even when token throws");
+    XCTAssertNotNil(install, @"Application Installed must still fire even when token throws");
     XCTAssertNil(install.properties[@"apple_ads_token"],
         @"apple_ads_token must be absent when token retrieval throws");
 #endif
@@ -272,7 +272,7 @@ static NSString *const kFPAA_VersionKey  = @"FPVersionKey";
 
     XCTAssertFalse(skanCalled, @"SKAN must not be called when skanConversionValue is 0");
     FPTrackPayload *install = [self capturedInstallPayload];
-    XCTAssertNotNil(install, @"app_install must still fire when SKAN is skipped");
+    XCTAssertNotNil(install, @"Application Installed must still fire when SKAN is skipped");
 #endif
 }
 

--- a/FreshpaintTests/FPDeepLinkAttributionTests.m
+++ b/FreshpaintTests/FPDeepLinkAttributionTests.m
@@ -362,13 +362,13 @@ static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
 }
 
 // ---------------------------------------------------------------------------
-#pragma mark - Test 10: app_install merges stored click IDs
+#pragma mark - Test 10: Application Installed merges stored click IDs
 // ---------------------------------------------------------------------------
 
 - (void)testAppInstallMergesStoredClickIds
 {
 #if TARGET_OS_IOS
-    // Pre-store a click ID so it is available when app_install fires.
+    // Pre-store a click ID so it is available when Application Installed fires.
     NSDictionary *clickId = @{
         @"$gclid": @"install_gclid",
         @"$gclid_creation_time": @((int64_t)([[NSDate date] timeIntervalSince1970] * 1000)),
@@ -380,10 +380,10 @@ static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:nil];
 
-    FPTrackPayload *installPayload = [self firstCapturedEventNamed:@"app_install"];
-    XCTAssertNotNil(installPayload, @"app_install must fire on first launch");
+    FPTrackPayload *installPayload = [self firstCapturedEventNamed:@"Application Installed"];
+    XCTAssertNotNil(installPayload, @"Application Installed must fire on first launch");
     XCTAssertNotNil(installPayload.properties[@"$gclid"],
-        @"$gclid must be merged into app_install properties from stored click IDs");
+        @"$gclid must be merged into Application Installed properties from stored click IDs");
 #else
     XCTSkip(@"This test requires iOS");
 #endif
@@ -536,12 +536,12 @@ static NSString *const kFPUTMExpiryKey  = @"com.freshpaint.utmExpiry";
 
     [self.analytics _applicationDidFinishLaunchingWithOptions:launchOptions];
 
-    FPTrackPayload *install = [self firstCapturedEventNamed:@"app_install"];
-    XCTAssertNotNil(install, @"app_install must fire on fresh launch with URL");
+    FPTrackPayload *install = [self firstCapturedEventNamed:@"Application Installed"];
+    XCTAssertNotNil(install, @"Application Installed must fire on fresh launch with URL");
     XCTAssertEqualObjects(install.properties[@"$ttclid"], @"tiktok_launch_99",
-        @"$ttclid from the launch URL must be merged into app_install payload");
+        @"$ttclid from the launch URL must be merged into Application Installed payload");
     XCTAssertEqualObjects(install.properties[@"utm_source"], @"tiktok",
-        @"utm_source from the launch URL must be merged into app_install payload");
+        @"utm_source from the launch URL must be merged into Application Installed payload");
 #endif
 }
 


### PR DESCRIPTION
## Summary

- Reverts install event name from `app_install` back to `Application Installed` to preserve backward compatibility with existing client pipelines across iOS, Android, and React Native (confirmed by Kyle Wright, 2026-04-27)
- Restores `version` and `build` payload field names (were renamed to `app_version` / `app_build` in FRP-37)
- All new MMP attribution fields remain unchanged (install_timestamp, persistent_device_id, idfv, att_status, idfa, apple_ads_token, click IDs, UTM params, etc.)
- Includes iOS 26 SwiftUI scene lifecycle fix: registers one-shot observers for `UIApplicationDidBecomeActiveNotification` and `UISceneDidActivateNotification` so `Application Installed` fires correctly on iOS 26 SwiftUI apps

## Test plan

- [ ] All 20 test suites pass (`make test-ios`)
- [ ] Clear install guard on simulator via "Clear Install Guard" button in demo app Deep Link Scenarios tab
- [ ] Stop and re-run demo app — `Application Installed` event appears in freshpaint.io within 5 seconds (debug flush interval)
- [ ] Confirm payload includes `version`, `build`, and all MMP attribution fields
- [ ] Confirm event does NOT re-fire on subsequent launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)