### PR TITLE
chore(ios): remove deprecated CTCarrier/CTTelephonyNetworkInfo usage

### DIFF
--- a/Freshpaint.podspec
+++ b/Freshpaint.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '15.1'
   s.tvos.deployment_target = '12.0'
 
-  s.ios.frameworks = 'CoreTelephony'
   s.ios.weak_frameworks = 'AppTrackingTransparency', 'AdServices'
   s.frameworks = 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
 

--- a/Freshpaint/Internal/FPUtils.m
+++ b/Freshpaint/Internal/FPUtils.m
@@ -11,12 +11,7 @@
 
 #include <sys/sysctl.h>
 
-#if TARGET_OS_IOS && TARGET_OS_MACCATALYST == 0
-#import <CoreTelephony/CTCarrier.h>
-#import <CoreTelephony/CTTelephonyNetworkInfo.h>
-
-static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
-#elif TARGET_OS_OSX
+#if TARGET_OS_OSX
 #import <Cocoa/Cocoa.h>
 #endif
 
@@ -355,23 +350,6 @@ NSDictionary *getLiveContext(FPReachability *reachability, NSDictionary *referre
             network[@"wifi"] = @(reachability.isReachableViaWiFi);
             network[@"cellular"] = @(reachability.isReachableViaWWAN);
         }
-
-#if TARGET_OS_IOS && TARGET_OS_MACCATALYST == 0
-        // CTCarrier and subscriberCellularProvider are deprecated in iOS 16+, where the API
-        // returns a stub carrier rather than real data. We keep reading it unconditionally to
-        // preserve the existing event-payload behavior across all iOS versions; the pragma only
-        // silences the build-time deprecation warning and changes nothing at runtime.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        static dispatch_once_t networkInfoOnceToken;
-        dispatch_once(&networkInfoOnceToken, ^{
-            _telephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
-        });
-        CTCarrier *carrier = [_telephonyNetworkInfo subscriberCellularProvider];
-        if (carrier.carrierName.length)
-            network[@"carrier"] = carrier.carrierName;
-#pragma clang diagnostic pop
-#endif
 
         network;
     });


### PR DESCRIPTION
## Summary

- Removes `CTCarrier` and `CTTelephonyNetworkInfo` usage from `FPUtils.m` — these APIs were deprecated in iOS 16+ and return an empty stub object on all devices above the 15.1 minimum target
- Removes the `#pragma clang diagnostic` suppression block that was silencing the deprecation warning
- Drops `CoreTelephony` from `Freshpaint.podspec` `ios.frameworks` — the framework is no longer referenced anywhere in the SDK
- The `network.carrier` field is removed from event payloads; it was already empty in practice on iOS 16+

## Linear

[FRP-108](https://linear.app/foxbox/issue/FRP-108) — chore(ios): remove deprecated CTCarrier/CTTelephonyNetworkInfo usage

## Test plan

- [x] All FreshpaintTests pass on iPhone 17 Simulator (iOS 26.5)
- [x] Zero CoreTelephony/CTCarrier/pragma-suppression symbols remain in source (verified by grep)
- [ ] Verify `network.wifi` and `network.cellular` still populate correctly in a real build
- [ ] Confirm `network.carrier` is absent from event payloads
- [ ] `pod lib lint` passes with updated podspec