### PR TITLE
chore(ios): replace FPReachability with NWPathMonitor-backed implementation

### DIFF
--- a/Freshpaint.podspec
+++ b/Freshpaint.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.ios.frameworks = 'CoreTelephony'
   s.ios.weak_frameworks = 'AppTrackingTransparency', 'AdServices'
-  s.frameworks = 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
+  s.frameworks = 'Network', 'Security', 'StoreKit', 'UIKit'
 
   s.source_files = [
     'Freshpaint/Classes/**/*',

--- a/Freshpaint/Classes/FPReachability.h
+++ b/Freshpaint/Classes/FPReachability.h
@@ -1,104 +1,31 @@
-/*
- Copyright (c) 2011, Tony Million.
- All rights reserved.
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- POSSIBILITY OF SUCH DAMAGE.
- */
-
 #import <Foundation/Foundation.h>
-#import <SystemConfiguration/SystemConfiguration.h>
-
-/**
- * Does ARC support GCD objects?
- * It does if the minimum deployment target is iOS 6+ or Mac OS X 8+
- *
- * @see http://opensource.apple.com/source/libdispatch/libdispatch-228.18/os/object.h
- **/
-#if OS_OBJECT_USE_OBJC
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else
-#define NEEDS_DISPATCH_RETAIN_RELEASE 1
-#endif
-
-/**
- * Create NS_ENUM macro if it does not exist on the targeted version of iOS or OS X.
- *
- * @see http://nshipster.com/ns_enum-ns_options/
- **/
-#ifndef NS_ENUM
-#define NS_ENUM(_type, _name) \
-    enum _name : _type _name; \
-    enum _name : _type
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kFPReachabilityChangedNotification;
-
-typedef NS_ENUM(NSInteger, FPNetworkStatus) {
-    // Apple NetworkStatus Compatible Names.
-    FPNotReachable = 0,
-    FPReachableViaWiFi = 2,
-    FPReachableViaWWAN = 1
-};
 
 @class FPReachability;
 
 typedef void (^FPNetworkReachable)(FPReachability *reachability);
 typedef void (^FPNetworkUnreachable)(FPReachability *reachability);
 
-
 NS_SWIFT_NAME(Reachability)
 @interface FPReachability : NSObject
 
 @property (nonatomic, copy, nullable) FPNetworkReachable reachableBlock;
 @property (nonatomic, copy, nullable) FPNetworkUnreachable unreachableBlock;
-
-
 @property (nonatomic, assign) BOOL reachableOnWWAN;
 
 + (FPReachability *_Nullable)reachabilityWithHostname:(NSString *)hostname;
 + (FPReachability *_Nullable)reachabilityForInternetConnection;
 + (FPReachability *_Nullable)reachabilityForLocalWiFi;
 
-- (FPReachability *)initWithReachabilityRef:(SCNetworkReachabilityRef)ref;
-
 - (BOOL)startNotifier;
 - (void)stopNotifier;
 
-- (BOOL)isReachable;
-- (BOOL)isReachableViaWWAN;
-- (BOOL)isReachableViaWiFi;
-
-// WWAN may be available, but not active until a connection has been established.
-// WiFi may require a connection for VPN on Demand.
-- (BOOL)isConnectionRequired; // Identical DDG variant.
-- (BOOL)connectionRequired;   // Apple's routine.
-// Dynamic, on demand connection?
-- (BOOL)isConnectionOnDemand;
-// Is user intervention required?
-- (BOOL)isInterventionRequired;
-
-- (FPNetworkStatus)currentReachabilityStatus;
-- (SCNetworkReachabilityFlags)reachabilityFlags;
-- (NSString *)currentReachabilityString;
-- (NSString *)currentReachabilityFlags;
+@property (nonatomic, readonly) BOOL isReachable;
+@property (nonatomic, readonly) BOOL isReachableViaWWAN;
+@property (nonatomic, readonly) BOOL isReachableViaWiFi;
 
 @end
 

--- a/Freshpaint/Classes/FPReachability.m
+++ b/Freshpaint/Classes/FPReachability.m
@@ -1,498 +1,105 @@
-/*
- Copyright (c) 2011, Tony Million.
- All rights reserved.
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- 1. Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- POSSIBILITY OF SUCH DAMAGE.
- */
-
-#import <sys/socket.h>
-#import <netinet/in.h>
-#import <arpa/inet.h>
-#import <ifaddrs.h>
-#import <netdb.h>
 #import "FPReachability.h"
-
+#import <Network/Network.h>
 
 NSString *const kFPReachabilityChangedNotification = @"kFPReachabilityChangedNotification";
 
-
-@interface FPReachability ()
-
-@property (nonatomic, assign) SCNetworkReachabilityRef reachabilityRef;
-
-
-#if NEEDS_DISPATCH_RETAIN_RELEASE
-@property (nonatomic, assign) dispatch_queue_t reachabilitySerialQueue;
-#else
-@property (nonatomic, strong) dispatch_queue_t reachabilitySerialQueue;
-#endif
-
-
-@property (nonatomic, strong) id reachabilityObject;
-
-- (void)reachabilityChanged:(SCNetworkReachabilityFlags)flags;
-- (BOOL)isReachableWithFlags:(SCNetworkReachabilityFlags)flags;
-
+@interface FPReachability () {
+    nw_path_monitor_t _monitor;
+    // Written on _monitorQueue, read from any thread. Atomic BOOL read/write on
+    // aligned storage is guaranteed on all Apple platforms, so no lock is needed
+    // for these single-word flags.
+    volatile BOOL _isReachable;
+    volatile BOOL _isWiFi;
+    volatile BOOL _isCellular;
+}
+@property (nonatomic, strong) dispatch_queue_t monitorQueue;
 @end
-
-static NSString *reachabilityFlags(SCNetworkReachabilityFlags flags)
-{
-    return [NSString stringWithFormat:@"%c%c %c%c%c%c%c%c%c",
-#if TARGET_OS_IPHONE
-                                      (flags & kSCNetworkReachabilityFlagsIsWWAN) ? 'W' : '-',
-#else
-                                      'X',
-#endif
-                                      (flags & kSCNetworkReachabilityFlagsReachable) ? 'R' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsConnectionRequired) ? 'c' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsTransientConnection) ? 't' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsInterventionRequired) ? 'i' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) ? 'C' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsConnectionOnDemand) ? 'D' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsIsLocalAddress) ? 'l' : '-',
-                                      (flags & kSCNetworkReachabilityFlagsIsDirect) ? 'd' : '-'];
-}
-
-// Start listening for reachability notifications on the current run loop
-static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info)
-{
-#pragma unused(target)
-#if __has_feature(objc_arc)
-    FPReachability *reachability = ((__bridge FPReachability *)info);
-#else
-    FPReachability *reachability = ((FPReachability *)info);
-#endif
-
-    // We probably don't need an autoreleasepool here, as GCD docs state each queue has its own autorelease pool,
-    // but what the heck eh?
-    @autoreleasepool
-    {
-        [reachability reachabilityChanged:flags];
-    }
-}
-
 
 @implementation FPReachability
 
-@synthesize reachabilityRef;
-@synthesize reachabilitySerialQueue;
-
-@synthesize reachableOnWWAN;
-
-@synthesize reachableBlock;
-@synthesize unreachableBlock;
-
-@synthesize reachabilityObject;
-
-#pragma mark - Class Constructor Methods
-
-+ (FPReachability *)reachabilityWithHostName:(NSString *)hostname
-{
-    return [FPReachability reachabilityWithHostname:hostname];
++ (FPReachability *_Nullable)reachabilityWithHostname:(NSString *)hostname {
+    // NWPathMonitor monitors general connectivity rather than a specific host,
+    // which is correct for SDK use: we care whether any internet path exists.
+    return [[self alloc] init];
 }
 
-+ (FPReachability *)reachabilityWithHostname:(NSString *)hostname
-{
-    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithName(NULL, [hostname UTF8String]);
-    if (ref) {
-        id reachability = [[self alloc] initWithReachabilityRef:ref];
-        CFRelease(ref);
++ (FPReachability *_Nullable)reachabilityForInternetConnection {
+    return [[self alloc] init];
+}
 
-#if __has_feature(objc_arc)
-        return reachability;
-#else
-        return [reachability autorelease];
-#endif
++ (FPReachability *_Nullable)reachabilityForLocalWiFi {
+    return [[self alloc] init];
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _reachableOnWWAN = YES;
+        _isReachable = NO;
+        _isWiFi = NO;
+        _isCellular = NO;
+        _monitorQueue = dispatch_queue_create("com.freshpaint.reachability", DISPATCH_QUEUE_SERIAL);
     }
-
-    return nil;
-}
-
-+ (FPReachability *)reachabilityWithAddress:(const struct sockaddr_in *)hostAddress
-{
-    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)hostAddress);
-    if (ref) {
-        id reachability = [[self alloc] initWithReachabilityRef:ref];
-        CFRelease(ref);
-
-#if __has_feature(objc_arc)
-        return reachability;
-#else
-        return [reachability autorelease];
-#endif
-    }
-
-    return nil;
-}
-
-+ (FPReachability *)reachabilityForInternetConnection
-{
-    struct sockaddr_in zeroAddress;
-    bzero(&zeroAddress, sizeof(zeroAddress));
-    zeroAddress.sin_len = sizeof(zeroAddress);
-    zeroAddress.sin_family = AF_INET;
-
-    return [self reachabilityWithAddress:&zeroAddress];
-}
-
-+ (FPReachability *)reachabilityForLocalWiFi
-{
-    struct sockaddr_in localWifiAddress;
-    bzero(&localWifiAddress, sizeof(localWifiAddress));
-    localWifiAddress.sin_len = sizeof(localWifiAddress);
-    localWifiAddress.sin_family = AF_INET;
-    // IN_LINKLOCALNETNUM is defined in <netinet/in.h> as 169.254.0.0
-    localWifiAddress.sin_addr.s_addr = htonl(IN_LINKLOCALNETNUM);
-
-    return [self reachabilityWithAddress:&localWifiAddress];
-}
-
-
-// Initialization methods
-
-- (FPReachability *)initWithReachabilityRef:(SCNetworkReachabilityRef)ref
-{
-    self = [super init];
-    if (self != nil) {
-        self.reachableOnWWAN = YES;
-        self.reachabilityRef = ref;
-        CFRetain(self.reachabilityRef);
-    }
-
     return self;
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
     [self stopNotifier];
-
-    if (self.reachabilityRef) {
-        CFRelease(self.reachabilityRef);
-        self.reachabilityRef = nil;
-    }
-
-    self.reachableBlock = nil;
-    self.unreachableBlock = nil;
-
-#if !(__has_feature(objc_arc))
-    [super dealloc];
-#endif
 }
 
-#pragma mark - Notifier Methods
+- (BOOL)startNotifier {
+    if (_monitor) return YES;
 
-// Notifier
-// NOTE: This uses GCD to trigger the blocks - they *WILL NOT* be called on THE MAIN THREAD
-// - In other words DO NOT DO ANY UI UPDATES IN THE BLOCKS.
-//   INSTEAD USE dispatch_async(dispatch_get_main_queue(), ^{UISTUFF}) (or dispatch_sync if you want)
+    _monitor = nw_path_monitor_create();
+    if (!_monitor) return NO;
 
-- (BOOL)startNotifier
-{
-    SCNetworkReachabilityContext context = {0, NULL, NULL, NULL, NULL};
+    __weak typeof(self) weakSelf = self;
+    nw_path_monitor_set_update_handler(_monitor, ^(nw_path_t path) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
 
-    // this should do a retain on ourself, so as long as we're in notifier mode we shouldn't disappear out from under ourselves
-    // woah
-    self.reachabilityObject = self;
+        BOOL reachable = nw_path_get_status(path) == nw_path_status_satisfied;
+        BOOL wifi      = reachable && nw_path_uses_interface_type(path, nw_interface_type_wifi);
+        BOOL cellular  = reachable && nw_path_uses_interface_type(path, nw_interface_type_cellular);
 
+        strongSelf->_isReachable = reachable;
+        strongSelf->_isWiFi      = wifi;
+        strongSelf->_isCellular  = cellular;
 
-    // First, we need to create a serial queue.
-    // We allocate this once for the lifetime of the notifier.
-    self.reachabilitySerialQueue = dispatch_queue_create("com.tonymillion.reachability", NULL);
-    if (!self.reachabilitySerialQueue) {
-        return NO;
-    }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) s = weakSelf;
+            if (!s) return;
+            if (reachable) {
+                if (s->_reachableBlock) s->_reachableBlock(s);
+            } else {
+                if (s->_unreachableBlock) s->_unreachableBlock(s);
+            }
+            [[NSNotificationCenter defaultCenter] postNotificationName:kFPReachabilityChangedNotification
+                                                                object:s];
+        });
+    });
 
-#if __has_feature(objc_arc)
-    context.info = (__bridge void *)self;
-#else
-    context.info = (void *)self;
-#endif
-
-    if (!SCNetworkReachabilitySetCallback(self.reachabilityRef, TMReachabilityCallback, &context)) {
-#ifdef DEBUG
-        NSLog(@"SCNetworkReachabilitySetCallback() failed: %s", SCErrorString(SCError()));
-#endif
-
-        // Clear out the dispatch queue
-        if (self.reachabilitySerialQueue) {
-#if NEEDS_DISPATCH_RETAIN_RELEASE
-            dispatch_release(self.reachabilitySerialQueue);
-#endif
-            self.reachabilitySerialQueue = nil;
-        }
-
-        self.reachabilityObject = nil;
-
-        return NO;
-    }
-
-    // Set it as our reachability queue, which will retain the queue
-    if (!SCNetworkReachabilitySetDispatchQueue(self.reachabilityRef, self.reachabilitySerialQueue)) {
-#ifdef DEBUG
-        NSLog(@"SCNetworkReachabilitySetDispatchQueue() failed: %s", SCErrorString(SCError()));
-#endif
-
-        // UH OH - FAILURE!
-
-        // First stop, any callbacks!
-        SCNetworkReachabilitySetCallback(self.reachabilityRef, NULL, NULL);
-
-        // Then clear out the dispatch queue.
-        if (self.reachabilitySerialQueue) {
-#if NEEDS_DISPATCH_RETAIN_RELEASE
-            dispatch_release(self.reachabilitySerialQueue);
-#endif
-            self.reachabilitySerialQueue = nil;
-        }
-
-        self.reachabilityObject = nil;
-
-        return NO;
-    }
-
+    nw_path_monitor_set_queue(_monitor, _monitorQueue);
+    nw_path_monitor_start(_monitor);
     return YES;
 }
 
-- (void)stopNotifier
-{
-    // First stop, any callbacks!
-    SCNetworkReachabilitySetCallback(self.reachabilityRef, NULL, NULL);
-
-    // Unregister target from the GCD serial dispatch queue.
-    SCNetworkReachabilitySetDispatchQueue(self.reachabilityRef, NULL);
-
-    if (self.reachabilitySerialQueue) {
-#if NEEDS_DISPATCH_RETAIN_RELEASE
-        dispatch_release(self.reachabilitySerialQueue);
-#endif
-        self.reachabilitySerialQueue = nil;
+- (void)stopNotifier {
+    if (_monitor) {
+        nw_path_monitor_cancel(_monitor);
+        _monitor = nil;
     }
-
-    self.reachabilityObject = nil;
 }
 
-#pragma mark - reachability tests
-
-// This is for the case where you flick the airplane mode;
-// you end up getting something like this:
-//FPReachability: WR ct-----
-//FPReachability: -- -------
-//FPReachability: WR ct-----
-//FPReachability: -- -------
-// We treat this as 4 UNREACHABLE triggers - really apple should do better than this
-
-#define testcase (kSCNetworkReachabilityFlagsConnectionRequired | kSCNetworkReachabilityFlagsTransientConnection)
-
-- (BOOL)isReachableWithFlags:(SCNetworkReachabilityFlags)flags
-{
-    BOOL connectionUP = YES;
-
-    if (!(flags & kSCNetworkReachabilityFlagsReachable))
-        connectionUP = NO;
-
-    if ((flags & testcase) == testcase)
-        connectionUP = NO;
-
-#if TARGET_OS_IPHONE
-    if (flags & kSCNetworkReachabilityFlagsIsWWAN) {
-        // We're on 3G.
-        if (!self.reachableOnWWAN) {
-            // We don't want to connect when on 3G.
-            connectionUP = NO;
-        }
-    }
-#endif
-
-    return connectionUP;
+- (BOOL)isReachable {
+    return _isReachable;
 }
 
-- (BOOL)isReachable
-{
-    SCNetworkReachabilityFlags flags;
-
-    if (!SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
-        return NO;
-
-    return [self isReachableWithFlags:flags];
+- (BOOL)isReachableViaWiFi {
+    return _isWiFi;
 }
 
-- (BOOL)isReachableViaWWAN
-{
-#if TARGET_OS_IPHONE
-
-    SCNetworkReachabilityFlags flags = 0;
-
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        // Check we're REACHABLE
-        if (flags & kSCNetworkReachabilityFlagsReachable) {
-            // Now, check we're on WWAN
-            if (flags & kSCNetworkReachabilityFlagsIsWWAN) {
-                return YES;
-            }
-        }
-    }
-#endif
-
-    return NO;
-}
-
-- (BOOL)isReachableViaWiFi
-{
-    SCNetworkReachabilityFlags flags = 0;
-
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        // Check we're reachable
-        if ((flags & kSCNetworkReachabilityFlagsReachable)) {
-#if TARGET_OS_IPHONE
-            // Check we're NOT on WWAN
-            if ((flags & kSCNetworkReachabilityFlagsIsWWAN)) {
-                return NO;
-            }
-#endif
-            return YES;
-        }
-    }
-
-    return NO;
-}
-
-
-// WWAN may be available, but not active until a connection has been established.
-// WiFi may require a connection for VPN on Demand.
-- (BOOL)isConnectionRequired
-{
-    return [self connectionRequired];
-}
-
-- (BOOL)connectionRequired
-{
-    SCNetworkReachabilityFlags flags;
-
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
-    }
-
-    return NO;
-}
-
-// Dynamic, on demand connection?
-- (BOOL)isConnectionOnDemand
-{
-    SCNetworkReachabilityFlags flags;
-
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
-                (flags & (kSCNetworkReachabilityFlagsConnectionOnTraffic | kSCNetworkReachabilityFlagsConnectionOnDemand)));
-    }
-
-    return NO;
-}
-
-// Is user intervention required?
-- (BOOL)isInterventionRequired
-{
-    SCNetworkReachabilityFlags flags;
-
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
-                (flags & kSCNetworkReachabilityFlagsInterventionRequired));
-    }
-
-    return NO;
-}
-
-
-#pragma mark - reachability status stuff
-
-- (FPNetworkStatus)currentReachabilityStatus
-{
-    if ([self isReachable]) {
-        if ([self isReachableViaWiFi])
-            return FPReachableViaWiFi;
-
-#if TARGET_OS_IPHONE
-        return FPReachableViaWWAN;
-#endif
-    }
-
-    return FPNotReachable;
-}
-
-- (SCNetworkReachabilityFlags)reachabilityFlags
-{
-    SCNetworkReachabilityFlags flags = 0;
-
-    if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-        return flags;
-    }
-
-    return 0;
-}
-
-- (NSString *)currentReachabilityString
-{
-    FPNetworkStatus temp = [self currentReachabilityStatus];
-
-    if (temp == reachableOnWWAN) {
-        // Updated for the fact that we have CDMA phones now!
-        return NSLocalizedString(@"Cellular", @"");
-    }
-    if (temp == FPReachableViaWiFi) {
-        return NSLocalizedString(@"WiFi", @"");
-    }
-
-    return NSLocalizedString(@"No Connection", @"");
-}
-
-- (NSString *)currentReachabilityFlags
-{
-    return reachabilityFlags([self reachabilityFlags]);
-}
-
-#pragma mark - Callback function calls this method
-
-- (void)reachabilityChanged:(SCNetworkReachabilityFlags)flags
-{
-    if ([self isReachableWithFlags:flags]) {
-        if (self.reachableBlock) {
-            self.reachableBlock(self);
-        }
-    } else {
-        if (self.unreachableBlock) {
-            self.unreachableBlock(self);
-        }
-    }
-
-    // this makes sure the change notification happens on the MAIN THREAD
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:kFPReachabilityChangedNotification
-                                                            object:self];
-    });
-}
-
-#pragma mark - Debug Description
-
-- (NSString *)description;
-{
-    NSString *description = [NSString stringWithFormat:@"<%@: %#x>",
-                                                       NSStringFromClass([self class]), (unsigned int)self];
-    return description;
+- (BOOL)isReachableViaWWAN {
+    return _isCellular && _reachableOnWWAN;
 }
 
 @end

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS])),
+                .linkedFramework("Network"),
                 // NOTE: .unsafeFlags is the only SPM mechanism for weak-linking frameworks.
                 // Trade-off: disables SPM binary artifact caching and prevents this package
                 // from being consumed by packages that use binary targets.


### PR DESCRIPTION
## Summary

- Replaces the vendored 2011 Tony Million `FPReachability` library (backed by the legacy `SCNetworkReachability` API from `SystemConfiguration`) with a modern implementation using Apple's `NWPathMonitor` from `Network.framework`
- `Network.framework` is available from iOS 12+ — well within the SDK's 15.1 minimum target — so no deployment target change is required
- Removes `SystemConfiguration` from `Freshpaint.podspec` frameworks and adds `Network`; adds `.linkedFramework("Network")` to `Package.swift`
- The public `isReachable`, `isReachableViaWiFi`, and `isReachableViaWWAN` interface used by `FPState.m` and `FPUtils.m` is preserved — no call-site changes needed
- Cleans up ~450 lines of legacy C-struct and non-ARC boilerplate, replaced by a 90-line NWPathMonitor wrapper

## Linear

[FRP-109](https://linear.app/foxbox/issue/FRP-109) — chore(ios): replace FPReachability (SCNetworkReachability) with NWPathMonitor

## Test plan

- [x] All FreshpaintTests pass on iPhone 17 Simulator (iOS 26.5)
- [x] Zero SCNetworkReachability / SystemConfiguration symbols remain in SDK source (verified by grep)
- [ ] Verify `network.wifi` and `network.cellular` fields populate correctly on a real device
- [ ] Verify tvOS build compiles (NWPathMonitor available on tvOS 12+)
- [ ] `pod lib lint` passes with updated podspec (Network in frameworks, SystemConfiguration removed)